### PR TITLE
security(renovate): pin Docker base image digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN git config --global --add safe.directory /src
 RUN GOOS=linux go build -v -buildvcs=true -o /app/rss2go ./cmd/rss2go
 RUN GOOS=linux go build -v -buildvcs=true -o /app/scraper ./cmd/scraper
 
-FROM alpine:latest
+FROM alpine:3.23
 
 # Certificates for HTTPS and timezone data
 RUN apk add --no-cache ca-certificates tzdata su-exec

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Pin Docker base images to a digest and keep the digest current, since the Dockerfile's golang and alpine images use floating tags.",
+      "matchCategories": ["docker"],
+      "pinDigests": true
+    },
+    {
+      "description": "Group all golang.org/x/* module updates into a single PR.",
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "groupName": "golang.org/x modules"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Part of an audit of Renovate configs across all managed repos after switching the runner to autodiscover.

- `golang:1.26.4-alpine` and `alpine:latest` in the Dockerfile were floating tags with no digest pin, and the bare `config:recommended` renovate.json never proposed one — same gap fixed in envoy-exporter.
- `alpine:latest` specifically had no version at all for Renovate to track version bumps against (only a digest, once pinning is enabled). Pinned it to `alpine:3.23` (current stable) so future bumps show up as a real version diff, not just a silent digest change.
- Added the same docker `pinDigests` packageRule gonzbd uses, plus PR throttle/labels/golang.org-x grouping (4 x/ modules here: net, sync, sys, text — would otherwise be 4 separate PRs).

## Test plan
- [ ] CI (ci.yml, security.yml) passes with `alpine:3.23`
- [ ] Merge, then watch for a Renovate PR that pins both `FROM` lines to a digest
- [ ] Confirm the built image still starts and the scraper/daemon containers run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)