### PR TITLE
security(renovate): reapply digest pinning; pin golang to a subversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY frontend/ ./
 RUN bun run build
 
 # Stage 2: Build the Go application
-FROM golang:1.26-alpine AS go-builder
+FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be AS go-builder
 WORKDIR /src
 RUN apk add --no-cache git
 COPY go.mod go.sum ./
@@ -19,7 +19,7 @@ RUN git config --global --add safe.directory /src || true
 RUN GOOS=linux go build -v -buildvcs=true -o /app/rss2go ./cmd/rss2go
 
 # Stage 3: Final lightweight execution environment
-FROM alpine:latest
+FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 RUN apk add --no-cache ca-certificates tzdata su-exec
 RUN adduser -D rss2go
 RUN mkdir -p /app/config /app/db && chown -R rss2go:rss2go /app

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,32 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Pin Docker base images to a digest and keep the digest current, since the Dockerfile's bun, golang, and alpine images use floating tags.",
+      "matchCategories": ["docker"],
+      "pinDigests": true
+    },
+    {
+      "description": "Group all golang.org/x/* module updates into a single PR.",
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "groupName": "golang.org/x modules"
+    },
+    {
+      "description": "Bundle the go.mod toolchain directive with the Dockerfile's golang base image into one PR, so both stay pinned to the same Go version together.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "groupName": "go toolchain version"
+    },
+    {
+      "description": "Bundle the Dockerfile's golang base image with the go.mod toolchain directive into one PR, so both stay pinned to the same Go version together.",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["golang"],
+      "groupName": "go toolchain version"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
This repo's Dockerfile went through a rewrite upstream (Svelte UI stage, restructured build) that dropped the renovate.json hardening merged in #86 (`pinDigests`, PR throttle, labels, `alpine:latest` -> pinned version) — that commit is no longer reachable from current `master`. This PR reapplies it against the new Dockerfile structure.

- `pinDigests: true` for docker, PR throttle, `dependencies` label, golang.org/x grouping — same as before
- New: pairs with gonzbd/envoy-exporter's go-toolchain `groupName` so a Go bump bundles the go.mod directive and Dockerfile image into one PR
- Standardizes the golang base image on a specific patch version (`1.26.5`) instead of the floating `1.26` tag, matching the other Docker-building repos
- `alpine:latest` (final stage) pinned to `3.23` (current stable) so version bumps show up as real diffs, not just silent digest changes

## Test plan
- [x] `docker buildx build` (full multi-stage) succeeds against both new digests
- [ ] Merge, then confirm the next Renovate run behaves as expected (no accidental onboarding/PR spam on this restructured Dockerfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)