### PR TITLE
fix(renovate): enable go.mod `go` directive bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,11 @@
       "groupName": "golang.org/x modules"
     },
     {
-      "description": "Bundle the go.mod toolchain directive with the Dockerfile's golang base image into one PR, so both stay pinned to the same Go version together.",
+      "description": "Bundle the go.mod toolchain directive with the Dockerfile's golang base image into one PR, so both stay pinned to the same Go version together. rss2go's go.mod has no separate `toolchain` line - the `go` directive itself is pinned to a full patch version (e.g. `go 1.26.4`) and serves that role. Renovate's default policy is to never bump the bare `go` directive (it treats it as a minimum-compatibility floor, not a pinned version), so matchDepNames+rangeStrategy=bump are required to opt in.",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
+      "matchDepNames": ["go"],
+      "rangeStrategy": "bump",
       "groupName": "go toolchain version"
     },
     {


### PR DESCRIPTION
## Summary
- rss2go's `go.mod` has no separate `toolchain` line — the `go` directive itself is pinned to a full patch version (e.g. `go 1.26.4`) and does double duty as both the compatibility floor and the effective pinned build version.
- Renovate's default policy never bumps a bare `go` directive, treating it as a minimum-compatibility constraint rather than something to keep current. This meant the existing "go toolchain version" packageRule (grouping gomod's `golang` depType with the Dockerfile's `golang` image) silently never produced a go.mod update — confirmed by PR history: golang Docker tag bumps to 1.26.3, 1.26.4, and 1.26.5 all landed with no matching go.mod change.
- Adds `matchDepNames: ["go"]` and `rangeStrategy: "bump"` to that rule, per [Renovate's docs](https://docs.renovatebot.com/modules/manager/gomod/), to opt in to bumping the `go` directive alongside the Dockerfile image.

## Test plan
- [ ] Next scheduled/manual Renovate run should propose a combined PR bumping both the Dockerfile's `golang:1.26.5-alpine` and go.mod's `go 1.26.5` together (or independently update go.mod on the next golang release)