### PR TITLE
feat(logging): audit and add debug logging across crawling, parsing, and email sending

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -53,6 +53,7 @@ All five must pass. Do not commit with failing tests, vet errors, or lint warnin
 
 - **Idioms:** "Accept interfaces, return structs." Define interfaces at the consumer side.
 - **Context:** Every blocking or cancellable operation **must** accept `context.Context` as the first parameter.
+- **Logging:** Use standard library `log/slog`. Every subsystem struct must accept a `*slog.Logger` in its constructor (defaulting to `slog.Default().With("component", "<name>")` if `nil`). Prefer structured key-value pairs (`url`, `id`, `err`, `duration`) over free-text formatting. Use `Debug` for operational tracing, `Info` for state transitions, `Warn` for fallbacks, and `Error` for unrecoverable step failures.
 - **Errors:** Wrap with `fmt.Errorf("component: ...: %w", err)`. Never use `%v` for errors that will be inspected.
 - **No hacks:** No `init()` for setup. No `panic` for control flow. No `time.Sleep` in tests — use channels or `sync.WaitGroup`.
 - **Standard library first:** Prefer `slices`, `maps`, `errors.Is/As`, `min`/`max` builtins over custom helpers or reflection.

--- a/cmd/rss2go/main.go
+++ b/cmd/rss2go/main.go
@@ -138,8 +138,8 @@ func main() {
 	repo := database.NewRepository(db)
 
 	// 2. Initialize crawler, extractor, and sanitizer
-	cr := crawler.NewCrawler(nil)
-	ex := extractor.NewExtractor(nil)
+	cr := crawler.NewCrawler(nil, slog.Default().With("component", "crawler"))
+	ex := extractor.NewExtractor(nil, slog.Default().With("component", "extractor"))
 	sa := sanitizer.NewSanitizer(800) // Default 800px width limit for emails
 
 	// 3. Initialize mail delivery notifier
@@ -163,10 +163,10 @@ func main() {
 			Password: cfg.SMTPPass,
 			From:     cfg.SMTPFrom,
 			Security: sec,
-		})
+		}, slog.Default().With("component", "notifier"))
 	case "sendmail":
 		slog.Info("Configuring sendmail binary notifier", "from", cfg.SMTPFrom)
-		delivery = notifier.NewSendmailSender("", cfg.SMTPFrom)
+		delivery = notifier.NewSendmailSender("", cfg.SMTPFrom, slog.Default().With("component", "notifier"))
 	case "mock":
 		slog.Info("Configuring dry-run mock mailer (logs only)")
 		delivery = &mockNotifier{}

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -1,11 +1,13 @@
 package crawler
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -47,8 +49,25 @@ func NewCrawler(client *http.Client, log ...*slog.Logger) *Crawler {
 	return &Crawler{client: client, log: l}
 }
 
+// SanitizeURL strips Basic Auth credentials (user:pass) and query/fragment parameters from raw URLs for safe logging.
+func SanitizeURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return rawURL
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
 // Crawl fetches the feed, respects HTTP cache headers, parses it, and extracts cache markers.
 func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
+	log := c.log
+	if log == nil {
+		log = slog.Default().With("component", "crawler")
+	}
+
 	u := f.URL
 	var mutateToInvalid bool
 	if strings.Contains(u, "mutate_url_to_invalid_after_crawl=1") {
@@ -58,11 +77,12 @@ func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
 		u = strings.TrimSuffix(u, "&")
 	}
 
-	c.log.Debug("Starting feed crawl", "feed_id", f.ID, "url", u, "etag", f.ETag, "last_modified", f.LastModified)
+	safeURL := SanitizeURL(u)
+	log.Debug("Starting feed crawl", "feed_id", f.ID, "url", safeURL, "etag", f.ETag, "last_modified", f.LastModified)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		c.log.Error("Failed to create HTTP request", "url", u, "err", err)
+		log.Debug("Failed to create HTTP request", "url", safeURL, "err", err)
 		return nil, fmt.Errorf("crawler: create request: %w", err)
 	}
 
@@ -81,28 +101,28 @@ func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
 	resp, err := c.client.Do(req)
 	duration := time.Since(start)
 	if err != nil {
-		c.log.Debug("Feed HTTP fetch failed", "url", u, "duration", duration, "err", err)
+		log.Debug("Feed HTTP fetch failed", "url", safeURL, "duration", duration, "err", err)
 		return nil, fmt.Errorf("crawler: fetch failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	c.log.Debug("Feed HTTP response received", "url", u, "status", resp.StatusCode, "duration", duration)
+	log.Debug("Feed HTTP response received", "url", safeURL, "status", resp.StatusCode, "duration", duration)
 
 	// Parse Retry-After headers if rate-limited or unavailable
 	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 		retryVal := resp.Header.Get("Retry-After")
 		duration := parseRetryAfter(retryVal)
-		c.log.Debug("Feed rate limited or unavailable", "url", u, "status", resp.StatusCode, "retry_after", retryVal)
+		log.Debug("Feed rate limited or unavailable", "url", safeURL, "status", resp.StatusCode, "retry_after", retryVal)
 		return &Result{RetryAfter: duration}, fmt.Errorf("crawler: server returned status %d", resp.StatusCode)
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		c.log.Debug("Feed not modified (304)", "url", u)
+		log.Debug("Feed not modified (304)", "url", safeURL)
 		return &Result{NotModified: true}, nil
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		c.log.Debug("Feed HTTP non-200 status", "url", u, "status", resp.StatusCode)
+		log.Debug("Feed HTTP non-200 status", "url", safeURL, "status", resp.StatusCode)
 		return nil, fmt.Errorf("crawler: server returned status %d %s", resp.StatusCode, resp.Status)
 	}
 
@@ -113,18 +133,18 @@ func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
 	// Read and parse feed body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		c.log.Debug("Failed reading feed response body", "url", u, "err", err)
+		log.Debug("Failed reading feed response body", "url", safeURL, "err", err)
 		return nil, fmt.Errorf("crawler: read body: %w", err)
 	}
 
 	parser := gofeed.NewParser()
-	parsedFeed, err := parser.ParseString(string(bodyBytes))
+	parsedFeed, err := parser.Parse(bytes.NewReader(bodyBytes))
 	if err != nil {
-		c.log.Debug("Failed parsing feed XML/Atom", "url", u, "bytes", len(bodyBytes), "err", err)
+		log.Debug("Failed parsing feed XML/Atom", "url", safeURL, "bytes", len(bodyBytes), "err", err)
 		return nil, fmt.Errorf("crawler: parse feed: %w", err)
 	}
 
-	c.log.Debug("Feed successfully parsed", "url", u, "title", parsedFeed.Title, "items", len(parsedFeed.Items))
+	log.Debug("Feed successfully parsed", "url", safeURL, "title", parsedFeed.Title, "items", len(parsedFeed.Items))
 
 	if mutateToInvalid {
 		f.URL = "http://invalid url/feed.xml"

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -26,17 +27,24 @@ type Result struct {
 // Crawler manages fetching and parsing of remote feed sources.
 type Crawler struct {
 	client *http.Client
+	log    *slog.Logger
 }
 
-// NewCrawler creates a new Crawler instance with the specified HTTP client.
-// If client is nil, http.DefaultClient is used.
-func NewCrawler(client *http.Client) *Crawler {
+// NewCrawler creates a new Crawler instance with the specified HTTP client and optional logger.
+// If client is nil, http.DefaultClient is used. If log is nil, slog.Default() is used.
+func NewCrawler(client *http.Client, log ...*slog.Logger) *Crawler {
 	if client == nil {
 		client = &http.Client{
 			Timeout: 30 * time.Second,
 		}
 	}
-	return &Crawler{client: client}
+	var l *slog.Logger
+	if len(log) > 0 && log[0] != nil {
+		l = log[0]
+	} else {
+		l = slog.Default().With("component", "crawler")
+	}
+	return &Crawler{client: client, log: l}
 }
 
 // Crawl fetches the feed, respects HTTP cache headers, parses it, and extracts cache markers.
@@ -50,8 +58,11 @@ func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
 		u = strings.TrimSuffix(u, "&")
 	}
 
+	c.log.Debug("Starting feed crawl", "feed_id", f.ID, "url", u, "etag", f.ETag, "last_modified", f.LastModified)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
+		c.log.Error("Failed to create HTTP request", "url", u, "err", err)
 		return nil, fmt.Errorf("crawler: create request: %w", err)
 	}
 
@@ -66,24 +77,32 @@ func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
 	// Identify as rss2go crawler
 	req.Header.Set("User-Agent", "rss2go/1.0 (Syndication Aggregator Daemon)")
 
+	start := time.Now()
 	resp, err := c.client.Do(req)
+	duration := time.Since(start)
 	if err != nil {
+		c.log.Debug("Feed HTTP fetch failed", "url", u, "duration", duration, "err", err)
 		return nil, fmt.Errorf("crawler: fetch failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	c.log.Debug("Feed HTTP response received", "url", u, "status", resp.StatusCode, "duration", duration)
 
 	// Parse Retry-After headers if rate-limited or unavailable
 	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 		retryVal := resp.Header.Get("Retry-After")
 		duration := parseRetryAfter(retryVal)
+		c.log.Debug("Feed rate limited or unavailable", "url", u, "status", resp.StatusCode, "retry_after", retryVal)
 		return &Result{RetryAfter: duration}, fmt.Errorf("crawler: server returned status %d", resp.StatusCode)
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
+		c.log.Debug("Feed not modified (304)", "url", u)
 		return &Result{NotModified: true}, nil
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		c.log.Debug("Feed HTTP non-200 status", "url", u, "status", resp.StatusCode)
 		return nil, fmt.Errorf("crawler: server returned status %d %s", resp.StatusCode, resp.Status)
 	}
 
@@ -94,14 +113,18 @@ func (c *Crawler) Crawl(ctx context.Context, f *types.Feed) (*Result, error) {
 	// Read and parse feed body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
+		c.log.Debug("Failed reading feed response body", "url", u, "err", err)
 		return nil, fmt.Errorf("crawler: read body: %w", err)
 	}
 
 	parser := gofeed.NewParser()
 	parsedFeed, err := parser.ParseString(string(bodyBytes))
 	if err != nil {
+		c.log.Debug("Failed parsing feed XML/Atom", "url", u, "bytes", len(bodyBytes), "err", err)
 		return nil, fmt.Errorf("crawler: parse feed: %w", err)
 	}
+
+	c.log.Debug("Feed successfully parsed", "url", u, "title", parsedFeed.Title, "items", len(parsedFeed.Items))
 
 	if mutateToInvalid {
 		f.URL = "http://invalid url/feed.xml"

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +38,7 @@ func TestCrawlHappyPath(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewCrawler(nil)
+	c := NewCrawler(nil, slog.New(slog.DiscardHandler))
 	feed := &types.Feed{
 		URL: server.URL,
 	}
@@ -77,7 +78,7 @@ func TestCrawlNotModified(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewCrawler(nil)
+	c := NewCrawler(nil, slog.New(slog.DiscardHandler))
 	feed := &types.Feed{
 		URL:          server.URL,
 		ETag:         `"etag-123"`,
@@ -104,7 +105,7 @@ func TestCrawlRetryAfterSeconds(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewCrawler(nil)
+	c := NewCrawler(nil, slog.New(slog.DiscardHandler))
 	feed := &types.Feed{URL: server.URL}
 
 	res, err := c.Crawl(context.Background(), feed)
@@ -125,7 +126,7 @@ func TestCrawlRetryAfterDate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewCrawler(nil)
+	c := NewCrawler(nil, slog.New(slog.DiscardHandler))
 	feed := &types.Feed{URL: server.URL}
 
 	res, err := c.Crawl(context.Background(), feed)
@@ -150,7 +151,7 @@ func TestCrawlErrorConditions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewCrawler(nil)
+	c := NewCrawler(nil, slog.New(slog.DiscardHandler))
 	feed := &types.Feed{URL: server.URL}
 
 	_, err := c.Crawl(context.Background(), feed)

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -40,13 +40,31 @@ func NewExtractor(client *http.Client, log ...*slog.Logger) *Extractor {
 	return &Extractor{client: client, log: l}
 }
 
+// SanitizeURL strips Basic Auth credentials (user:pass) and query/fragment parameters from raw URLs for safe logging.
+func SanitizeURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return rawURL
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
 // Extract fetches the page at targetURL and extracts the content based on strategy.
 func (e *Extractor) Extract(ctx context.Context, targetURL string, strategy types.ExtractionStrategy, selector string) (string, error) {
-	e.log.Debug("Starting article extraction", "url", targetURL, "strategy", strategy, "selector", selector)
+	log := e.log
+	if log == nil {
+		log = slog.Default().With("component", "extractor")
+	}
+
+	safeURL := SanitizeURL(targetURL)
+	log.Debug("Starting article extraction", "url", safeURL, "strategy", strategy, "selector", selector)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
-		e.log.Debug("Failed creating HTTP request for article extraction", "url", targetURL, "err", err)
+		log.Debug("Failed creating HTTP request for article extraction", "url", safeURL, "err", err)
 		return "", fmt.Errorf("extractor: create request: %w", err)
 	}
 
@@ -56,19 +74,19 @@ func (e *Extractor) Extract(ctx context.Context, targetURL string, strategy type
 	resp, err := e.client.Do(req)
 	duration := time.Since(start)
 	if err != nil {
-		e.log.Debug("Article fetch failed", "url", targetURL, "duration", duration, "err", err)
+		log.Debug("Article fetch failed", "url", safeURL, "duration", duration, "err", err)
 		return "", fmt.Errorf("extractor: fetch failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		e.log.Debug("Article fetch non-200 HTTP status", "url", targetURL, "status", resp.StatusCode)
+		log.Debug("Article fetch non-200 HTTP status", "url", safeURL, "status", resp.StatusCode)
 		return "", fmt.Errorf("extractor: fetch returned HTTP status %d", resp.StatusCode)
 	}
 
 	contentType := resp.Header.Get("Content-Type")
 	if !strings.Contains(contentType, "text/html") && !strings.Contains(contentType, "application/xhtml+xml") {
-		e.log.Debug("Article content-type unsupported for extraction", "url", targetURL, "content_type", contentType)
+		log.Debug("Article content-type unsupported for extraction", "url", safeURL, "content_type", contentType)
 		return "", fmt.Errorf("extractor: unsupported content type %q", contentType)
 	}
 
@@ -77,55 +95,62 @@ func (e *Extractor) Extract(ctx context.Context, targetURL string, strategy type
 
 // ExtractFromReader extracts content from an HTML reader.
 func (e *Extractor) ExtractFromReader(r io.Reader, targetURL string, strategy types.ExtractionStrategy, selector string) (string, error) {
+	log := e.log
+	if log == nil {
+		log = slog.Default().With("component", "extractor")
+	}
+
+	safeURL := SanitizeURL(targetURL)
+
 	switch strategy {
 	case types.StrategyHeuristic:
 		parsedURL, err := url.Parse(targetURL)
 		if err != nil {
-			e.log.Debug("Invalid target URL for readability", "url", targetURL, "err", err)
+			log.Debug("Invalid target URL for readability", "url", safeURL, "err", err)
 			return "", fmt.Errorf("extractor: invalid target URL: %w", err)
 		}
 		article, err := readability.FromReader(r, parsedURL)
 		if err != nil {
-			e.log.Debug("Readability extraction failed", "url", targetURL, "err", err)
+			log.Debug("Readability extraction failed", "url", safeURL, "err", err)
 			return "", fmt.Errorf("extractor: readability extraction failed: %w", err)
 		}
 		var buf bytes.Buffer
 		if err := article.RenderHTML(&buf); err != nil {
-			e.log.Debug("Readability HTML render failed", "url", targetURL, "err", err)
+			log.Debug("Readability HTML render failed", "url", safeURL, "err", err)
 			return "", fmt.Errorf("extractor: render article HTML: %w", err)
 		}
 		extracted := buf.String()
-		e.log.Debug("Readability extraction succeeded", "url", targetURL, "bytes", len(extracted))
+		log.Debug("Readability extraction succeeded", "url", safeURL, "bytes", len(extracted))
 		return extracted, nil
 
 	case types.StrategySelector:
 		if selector == "" {
-			e.log.Debug("CSS selector empty for selector strategy", "url", targetURL)
+			log.Debug("CSS selector empty for selector strategy", "url", safeURL)
 			return "", fmt.Errorf("extractor: structural selector strategy requires a non-empty CSS selector")
 		}
 		doc, err := goquery.NewDocumentFromReader(r)
 		if err != nil {
-			e.log.Debug("Failed parsing HTML document for selector extraction", "url", targetURL, "err", err)
+			log.Debug("Failed parsing HTML document for selector extraction", "url", safeURL, "err", err)
 			return "", fmt.Errorf("extractor: parse HTML document: %w", err)
 		}
 
 		selection := doc.Find(selector)
 		if selection.Length() == 0 {
-			e.log.Debug("CSS selector matched no elements", "url", targetURL, "selector", selector)
+			log.Debug("CSS selector matched no elements", "url", safeURL, "selector", selector)
 			return "", fmt.Errorf("extractor: CSS selector %q matched no elements", selector)
 		}
 
 		// Return the HTML of the matched elements.
 		html, err := selection.Html()
 		if err != nil {
-			e.log.Debug("Failed rendering CSS selector HTML match", "url", targetURL, "selector", selector, "err", err)
+			log.Debug("Failed rendering CSS selector HTML match", "url", safeURL, "selector", selector, "err", err)
 			return "", fmt.Errorf("extractor: render matched HTML: %w", err)
 		}
-		e.log.Debug("CSS selector extraction succeeded", "url", targetURL, "selector", selector, "bytes", len(html))
+		log.Debug("CSS selector extraction succeeded", "url", safeURL, "selector", selector, "bytes", len(html))
 		return html, nil
 
 	default:
-		e.log.Debug("Unsupported extraction strategy", "url", targetURL, "strategy", strategy)
+		log.Debug("Unsupported extraction strategy", "url", safeURL, "strategy", strategy)
 		return "", fmt.Errorf("extractor: unsupported extraction strategy %q", strategy)
 	}
 }

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -19,40 +20,55 @@ import (
 // Extractor manages fetching remote destination articles and extracting their primary content.
 type Extractor struct {
 	client *http.Client
+	log    *slog.Logger
 }
 
 // NewExtractor creates a new Extractor instance.
-// If client is nil, http.DefaultClient is used.
-func NewExtractor(client *http.Client) *Extractor {
+// If client is nil, http.DefaultClient is used. If log is nil, slog.Default() is used.
+func NewExtractor(client *http.Client, log ...*slog.Logger) *Extractor {
 	if client == nil {
 		client = &http.Client{
 			Timeout: 15 * time.Second,
 		}
 	}
-	return &Extractor{client: client}
+	var l *slog.Logger
+	if len(log) > 0 && log[0] != nil {
+		l = log[0]
+	} else {
+		l = slog.Default().With("component", "extractor")
+	}
+	return &Extractor{client: client, log: l}
 }
 
 // Extract fetches the page at targetURL and extracts the content based on strategy.
 func (e *Extractor) Extract(ctx context.Context, targetURL string, strategy types.ExtractionStrategy, selector string) (string, error) {
+	e.log.Debug("Starting article extraction", "url", targetURL, "strategy", strategy, "selector", selector)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
+		e.log.Debug("Failed creating HTTP request for article extraction", "url", targetURL, "err", err)
 		return "", fmt.Errorf("extractor: create request: %w", err)
 	}
 
 	req.Header.Set("User-Agent", "rss2go/1.0 (Full Article Extractor)")
 
+	start := time.Now()
 	resp, err := e.client.Do(req)
+	duration := time.Since(start)
 	if err != nil {
+		e.log.Debug("Article fetch failed", "url", targetURL, "duration", duration, "err", err)
 		return "", fmt.Errorf("extractor: fetch failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		e.log.Debug("Article fetch non-200 HTTP status", "url", targetURL, "status", resp.StatusCode)
 		return "", fmt.Errorf("extractor: fetch returned HTTP status %d", resp.StatusCode)
 	}
 
 	contentType := resp.Header.Get("Content-Type")
 	if !strings.Contains(contentType, "text/html") && !strings.Contains(contentType, "application/xhtml+xml") {
+		e.log.Debug("Article content-type unsupported for extraction", "url", targetURL, "content_type", contentType)
 		return "", fmt.Errorf("extractor: unsupported content type %q", contentType)
 	}
 
@@ -65,40 +81,51 @@ func (e *Extractor) ExtractFromReader(r io.Reader, targetURL string, strategy ty
 	case types.StrategyHeuristic:
 		parsedURL, err := url.Parse(targetURL)
 		if err != nil {
+			e.log.Debug("Invalid target URL for readability", "url", targetURL, "err", err)
 			return "", fmt.Errorf("extractor: invalid target URL: %w", err)
 		}
 		article, err := readability.FromReader(r, parsedURL)
 		if err != nil {
+			e.log.Debug("Readability extraction failed", "url", targetURL, "err", err)
 			return "", fmt.Errorf("extractor: readability extraction failed: %w", err)
 		}
 		var buf bytes.Buffer
 		if err := article.RenderHTML(&buf); err != nil {
+			e.log.Debug("Readability HTML render failed", "url", targetURL, "err", err)
 			return "", fmt.Errorf("extractor: render article HTML: %w", err)
 		}
-		return buf.String(), nil
+		extracted := buf.String()
+		e.log.Debug("Readability extraction succeeded", "url", targetURL, "bytes", len(extracted))
+		return extracted, nil
 
 	case types.StrategySelector:
 		if selector == "" {
+			e.log.Debug("CSS selector empty for selector strategy", "url", targetURL)
 			return "", fmt.Errorf("extractor: structural selector strategy requires a non-empty CSS selector")
 		}
 		doc, err := goquery.NewDocumentFromReader(r)
 		if err != nil {
+			e.log.Debug("Failed parsing HTML document for selector extraction", "url", targetURL, "err", err)
 			return "", fmt.Errorf("extractor: parse HTML document: %w", err)
 		}
 
 		selection := doc.Find(selector)
 		if selection.Length() == 0 {
+			e.log.Debug("CSS selector matched no elements", "url", targetURL, "selector", selector)
 			return "", fmt.Errorf("extractor: CSS selector %q matched no elements", selector)
 		}
 
 		// Return the HTML of the matched elements.
 		html, err := selection.Html()
 		if err != nil {
+			e.log.Debug("Failed rendering CSS selector HTML match", "url", targetURL, "selector", selector, "err", err)
 			return "", fmt.Errorf("extractor: render matched HTML: %w", err)
 		}
+		e.log.Debug("CSS selector extraction succeeded", "url", targetURL, "selector", selector, "bytes", len(html))
 		return html, nil
 
 	default:
+		e.log.Debug("Unsupported extraction strategy", "url", targetURL, "strategy", strategy)
 		return "", fmt.Errorf("extractor: unsupported extraction strategy %q", strategy)
 	}
 }

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -29,7 +30,7 @@ const sampleArticleHTML = `
 </html>`
 
 func TestExtractCSSSelector(t *testing.T) {
-	e := NewExtractor(nil)
+	e := NewExtractor(nil, slog.New(slog.DiscardHandler))
 
 	// Happy Path
 	r := strings.NewReader(sampleArticleHTML)
@@ -61,7 +62,7 @@ func TestExtractCSSSelector(t *testing.T) {
 }
 
 func TestExtractHeuristic(t *testing.T) {
-	e := NewExtractor(nil)
+	e := NewExtractor(nil, slog.New(slog.DiscardHandler))
 
 	r := strings.NewReader(sampleArticleHTML)
 	res, err := e.ExtractFromReader(r, "https://example.com/article", types.StrategyHeuristic, "")
@@ -79,7 +80,7 @@ func TestExtractHeuristic(t *testing.T) {
 }
 
 func TestExtractUnsupportedStrategy(t *testing.T) {
-	e := NewExtractor(nil)
+	e := NewExtractor(nil, slog.New(slog.DiscardHandler))
 	r := strings.NewReader(sampleArticleHTML)
 	_, err := e.ExtractFromReader(r, "https://example.com", "unknown", "")
 	if err == nil {
@@ -95,7 +96,7 @@ func TestExtractNetworkCalls(t *testing.T) {
 	}))
 	defer server.Close()
 
-	e := NewExtractor(nil)
+	e := NewExtractor(nil, slog.New(slog.DiscardHandler))
 
 	// Happy path
 	res, err := e.Extract(context.Background(), server.URL, types.StrategySelector, "article h1")

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -60,8 +60,13 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 		return fmt.Errorf("notifier: smtp: no recipients specified")
 	}
 
+	log := s.log
+	if log == nil {
+		log = slog.Default().With("component", "notifier")
+	}
+
 	cleanedSubject := CleanHeader(subject)
-	s.log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", cleanedSubject)
+	log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", cleanedSubject)
 
 	msg := buildMessage(s.cfg.From, recipients, cleanedSubject, body)
 
@@ -82,14 +87,14 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 		conn, err = dialer.DialContext(ctx, "tcp", addr)
 	}
 	if err != nil {
-		s.log.Debug("SMTP connection failed", "addr", addr, "security", s.cfg.Security, "err", err)
+		log.Debug("SMTP connection failed", "addr", addr, "security", s.cfg.Security, "err", err)
 		return fmt.Errorf("notifier: smtp dial failed: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
 
 	client, err := smtp.NewClient(conn, s.cfg.Host)
 	if err != nil {
-		s.log.Debug("Failed creating SMTP client", "host", s.cfg.Host, "err", err)
+		log.Debug("Failed creating SMTP client", "host", s.cfg.Host, "err", err)
 		return fmt.Errorf("notifier: create smtp client: %w", err)
 	}
 	defer func() { _ = client.Close() }()
@@ -101,7 +106,7 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 			MinVersion: tls.VersionTLS12,
 		}
 		if err := client.StartTLS(tlsConfig); err != nil {
-			s.log.Debug("SMTP STARTTLS failed", "host", s.cfg.Host, "err", err)
+			log.Debug("SMTP STARTTLS failed", "host", s.cfg.Host, "err", err)
 			return fmt.Errorf("notifier: starttls failed: %w", err)
 		}
 	}
@@ -110,20 +115,20 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 	if s.cfg.Username != "" {
 		auth := smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
 		if err := client.Auth(auth); err != nil {
-			s.log.Debug("SMTP authentication failed", "user", s.cfg.Username, "err", err)
+			log.Debug("SMTP authentication failed", "user", s.cfg.Username, "err", err)
 			return fmt.Errorf("notifier: authentication failed: %w", err)
 		}
 	}
 
 	// Set sender and recipients
 	if err := client.Mail(s.cfg.From); err != nil {
-		s.log.Debug("SMTP MAIL FROM command failed", "from", s.cfg.From, "err", err)
+		log.Debug("SMTP MAIL FROM command failed", "from", s.cfg.From, "err", err)
 		return fmt.Errorf("notifier: set mail from: %w", err)
 	}
 
 	for _, to := range recipients {
 		if err := client.Rcpt(to); err != nil {
-			s.log.Debug("SMTP RCPT TO command failed", "to", to, "err", err)
+			log.Debug("SMTP RCPT TO command failed", "to", to, "err", err)
 			return fmt.Errorf("notifier: set rcpt to %s: %w", to, err)
 		}
 	}
@@ -131,22 +136,22 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 	// Write body
 	w, err := client.Data()
 	if err != nil {
-		s.log.Debug("SMTP DATA command failed", "err", err)
+		log.Debug("SMTP DATA command failed", "err", err)
 		return fmt.Errorf("notifier: open data writer: %w", err)
 	}
 
 	if _, err := w.Write(msg); err != nil {
 		_ = w.Close()
-		s.log.Debug("SMTP message data write failed", "err", err)
+		log.Debug("SMTP message data write failed", "err", err)
 		return fmt.Errorf("notifier: write message data: %w", err)
 	}
 
 	if err := w.Close(); err != nil {
-		s.log.Debug("SMTP DATA termination failed", "err", err)
+		log.Debug("SMTP DATA termination failed", "err", err)
 		return fmt.Errorf("notifier: close data writer: %w", err)
 	}
 
-	s.log.Debug("SMTP email delivered successfully", "recipients_count", len(recipients), "bytes", len(msg))
+	log.Debug("SMTP email delivered successfully", "recipients_count", len(recipients), "bytes", len(msg))
 	return nil
 }
 
@@ -182,8 +187,13 @@ func (s *SendmailSender) Send(ctx context.Context, subject string, body string, 
 		return fmt.Errorf("notifier: sendmail: no recipients specified")
 	}
 
+	log := s.log
+	if log == nil {
+		log = slog.Default().With("component", "notifier")
+	}
+
 	cleanedSubject := CleanHeader(subject)
-	s.log.Debug("Starting sendmail binary delivery", "path", s.path, "recipients_count", len(recipients), "subject", cleanedSubject)
+	log.Debug("Starting sendmail binary delivery", "path", s.path, "recipients_count", len(recipients), "subject", cleanedSubject)
 
 	msg := buildMessage(s.from, recipients, cleanedSubject, body)
 
@@ -195,11 +205,11 @@ func (s *SendmailSender) Send(ctx context.Context, subject string, body string, 
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		s.log.Debug("Sendmail execution failed", "path", s.path, "stderr", stderr.String(), "err", err)
+		log.Debug("Sendmail execution failed", "path", s.path, "stderr", stderr.String(), "err", err)
 		return fmt.Errorf("notifier: sendmail failed (stderr: %q): %w", stderr.String(), err)
 	}
 
-	s.log.Debug("Sendmail binary delivery succeeded", "recipients_count", len(recipients), "bytes", len(msg))
+	log.Debug("Sendmail binary delivery succeeded", "recipients_count", len(recipients), "bytes", len(msg))
 	return nil
 }
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/smtp"
 	"os/exec"
@@ -39,11 +40,18 @@ type Sender interface {
 // SMTPSender implements email dispatching via SMTP.
 type SMTPSender struct {
 	cfg SMTPConfig
+	log *slog.Logger
 }
 
-// NewSMTPSender creates a new SMTPSender.
-func NewSMTPSender(cfg SMTPConfig) *SMTPSender {
-	return &SMTPSender{cfg: cfg}
+// NewSMTPSender creates a new SMTPSender with optional logger.
+func NewSMTPSender(cfg SMTPConfig, log ...*slog.Logger) *SMTPSender {
+	var l *slog.Logger
+	if len(log) > 0 && log[0] != nil {
+		l = log[0]
+	} else {
+		l = slog.Default().With("component", "notifier")
+	}
+	return &SMTPSender{cfg: cfg, log: l}
 }
 
 // Send dispatches an HTML email to recipients via SMTP.
@@ -51,6 +59,8 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 	if len(recipients) == 0 {
 		return fmt.Errorf("notifier: smtp: no recipients specified")
 	}
+
+	s.log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", subject)
 
 	cleanedSubject := CleanHeader(subject)
 	msg := buildMessage(s.cfg.From, recipients, cleanedSubject, body)
@@ -72,12 +82,14 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 		conn, err = dialer.DialContext(ctx, "tcp", addr)
 	}
 	if err != nil {
+		s.log.Debug("SMTP connection failed", "addr", addr, "security", s.cfg.Security, "err", err)
 		return fmt.Errorf("notifier: smtp dial failed: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
 
 	client, err := smtp.NewClient(conn, s.cfg.Host)
 	if err != nil {
+		s.log.Debug("Failed creating SMTP client", "host", s.cfg.Host, "err", err)
 		return fmt.Errorf("notifier: create smtp client: %w", err)
 	}
 	defer func() { _ = client.Close() }()
@@ -89,6 +101,7 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 			MinVersion: tls.VersionTLS12,
 		}
 		if err := client.StartTLS(tlsConfig); err != nil {
+			s.log.Debug("SMTP STARTTLS failed", "host", s.cfg.Host, "err", err)
 			return fmt.Errorf("notifier: starttls failed: %w", err)
 		}
 	}
@@ -97,17 +110,20 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 	if s.cfg.Username != "" {
 		auth := smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
 		if err := client.Auth(auth); err != nil {
+			s.log.Debug("SMTP authentication failed", "user", s.cfg.Username, "err", err)
 			return fmt.Errorf("notifier: authentication failed: %w", err)
 		}
 	}
 
 	// Set sender and recipients
 	if err := client.Mail(s.cfg.From); err != nil {
+		s.log.Debug("SMTP MAIL FROM command failed", "from", s.cfg.From, "err", err)
 		return fmt.Errorf("notifier: set mail from: %w", err)
 	}
 
 	for _, to := range recipients {
 		if err := client.Rcpt(to); err != nil {
+			s.log.Debug("SMTP RCPT TO command failed", "to", to, "err", err)
 			return fmt.Errorf("notifier: set rcpt to %s: %w", to, err)
 		}
 	}
@@ -115,14 +131,17 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 	// Write body
 	w, err := client.Data()
 	if err != nil {
+		s.log.Debug("SMTP DATA command failed", "err", err)
 		return fmt.Errorf("notifier: open data writer: %w", err)
 	}
 	defer func() { _ = w.Close() }()
 
 	if _, err := w.Write(msg); err != nil {
+		s.log.Debug("SMTP message data write failed", "err", err)
 		return fmt.Errorf("notifier: write message data: %w", err)
 	}
 
+	s.log.Debug("SMTP email delivered successfully", "recipients_count", len(recipients), "bytes", len(msg))
 	return nil
 }
 
@@ -130,17 +149,25 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 type SendmailSender struct {
 	path string
 	from string
+	log  *slog.Logger
 }
 
-// NewSendmailSender creates a new SendmailSender.
+// NewSendmailSender creates a new SendmailSender with optional logger.
 // If path is empty, /usr/sbin/sendmail is used.
-func NewSendmailSender(path string, from string) *SendmailSender {
+func NewSendmailSender(path string, from string, log ...*slog.Logger) *SendmailSender {
 	if path == "" {
 		path = "/usr/sbin/sendmail"
+	}
+	var l *slog.Logger
+	if len(log) > 0 && log[0] != nil {
+		l = log[0]
+	} else {
+		l = slog.Default().With("component", "notifier")
 	}
 	return &SendmailSender{
 		path: path,
 		from: from,
+		log:  l,
 	}
 }
 
@@ -149,6 +176,8 @@ func (s *SendmailSender) Send(ctx context.Context, subject string, body string, 
 	if len(recipients) == 0 {
 		return fmt.Errorf("notifier: sendmail: no recipients specified")
 	}
+
+	s.log.Debug("Starting sendmail binary delivery", "path", s.path, "recipients_count", len(recipients), "subject", subject)
 
 	cleanedSubject := CleanHeader(subject)
 	msg := buildMessage(s.from, recipients, cleanedSubject, body)
@@ -161,9 +190,11 @@ func (s *SendmailSender) Send(ctx context.Context, subject string, body string, 
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
+		s.log.Debug("Sendmail execution failed", "path", s.path, "stderr", stderr.String(), "err", err)
 		return fmt.Errorf("notifier: sendmail failed (stderr: %q): %w", stderr.String(), err)
 	}
 
+	s.log.Debug("Sendmail binary delivery succeeded", "recipients_count", len(recipients), "bytes", len(msg))
 	return nil
 }
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -60,9 +60,9 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 		return fmt.Errorf("notifier: smtp: no recipients specified")
 	}
 
-	s.log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", subject)
-
 	cleanedSubject := CleanHeader(subject)
+	s.log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", cleanedSubject)
+
 	msg := buildMessage(s.cfg.From, recipients, cleanedSubject, body)
 
 	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
@@ -182,9 +182,9 @@ func (s *SendmailSender) Send(ctx context.Context, subject string, body string, 
 		return fmt.Errorf("notifier: sendmail: no recipients specified")
 	}
 
-	s.log.Debug("Starting sendmail binary delivery", "path", s.path, "recipients_count", len(recipients), "subject", subject)
-
 	cleanedSubject := CleanHeader(subject)
+	s.log.Debug("Starting sendmail binary delivery", "path", s.path, "recipients_count", len(recipients), "subject", cleanedSubject)
+
 	msg := buildMessage(s.from, recipients, cleanedSubject, body)
 
 	// Invoke local sendmail binary: sendmail -t

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -134,11 +134,16 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 		s.log.Debug("SMTP DATA command failed", "err", err)
 		return fmt.Errorf("notifier: open data writer: %w", err)
 	}
-	defer func() { _ = w.Close() }()
 
 	if _, err := w.Write(msg); err != nil {
+		_ = w.Close()
 		s.log.Debug("SMTP message data write failed", "err", err)
 		return fmt.Errorf("notifier: write message data: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		s.log.Debug("SMTP DATA termination failed", "err", err)
+		return fmt.Errorf("notifier: close data writer: %w", err)
 	}
 
 	s.log.Debug("SMTP email delivered successfully", "recipients_count", len(recipients), "bytes", len(msg))

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -197,3 +197,131 @@ func TestSMTPSenderHappyPath(t *testing.T) {
 		t.Fatalf("SMTP send failed: %v", err)
 	}
 }
+
+func TestNilLoggerGuards(t *testing.T) {
+	addr, closeFn := startMockSMTPServer(t)
+	defer closeFn()
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
+
+	var port int
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+
+	// Directly initialize SMTPSender with nil log field (struct literal without NewSMTPSender)
+	smtpSender := &SMTPSender{
+		cfg: SMTPConfig{
+			Host:     host,
+			Port:     port,
+			Username: "user",
+			Password: "pass",
+			From:     "sender@test.com",
+			Security: SecurityNone,
+		},
+		log: nil,
+	}
+
+	if err := smtpSender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("SMTPSender.Send with nil logger failed: %v", err)
+	}
+
+	// Directly initialize SendmailSender with nil log field
+	tempDir := t.TempDir()
+	mockSendmailPath := filepath.Join(tempDir, "sendmail")
+	scriptContent := fmt.Sprintf("#!/bin/sh\ncat > %s.out\n", mockSendmailPath)
+	if err := os.WriteFile(mockSendmailPath, []byte(scriptContent), 0755); err != nil {
+		t.Fatalf("failed to write mock sendmail: %v", err)
+	}
+
+	sendmailSender := &SendmailSender{
+		path: mockSendmailPath,
+		from: "sender@test.com",
+		log:  nil,
+	}
+
+	if err := sendmailSender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("SendmailSender.Send with nil logger failed: %v", err)
+	}
+}
+
+func TestSMTPSenderDataCloseError(t *testing.T) {
+	// Start a mock server that returns 554 error after receiving "." in DATA
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		reader := bufio.NewReader(conn)
+		tp := textproto.NewReader(reader)
+
+		_, _ = conn.Write([]byte("220 smtp.mock.test\r\n"))
+
+		for {
+			line, err := tp.ReadLine()
+			if err != nil {
+				return
+			}
+			cmd := strings.ToUpper(line)
+			if strings.HasPrefix(cmd, "EHLO") || strings.HasPrefix(cmd, "HELO") {
+				_, _ = conn.Write([]byte("250-smtp.mock.test Hello\r\n250 AUTH PLAIN\r\n"))
+			} else if strings.HasPrefix(cmd, "AUTH PLAIN") {
+				_, _ = conn.Write([]byte("235 2.7.0 Authentication successful\r\n"))
+			} else if strings.HasPrefix(cmd, "MAIL FROM:") {
+				_, _ = conn.Write([]byte("250 2.1.0 Ok\r\n"))
+			} else if strings.HasPrefix(cmd, "RCPT TO:") {
+				_, _ = conn.Write([]byte("250 2.1.5 Ok\r\n"))
+			} else if cmd == "DATA" {
+				_, _ = conn.Write([]byte("354 Start mail input; end with <CR><LF>.<CR><LF>\r\n"))
+				for {
+					bodyLine, err := tp.ReadLine()
+					if err != nil {
+						return
+					}
+					if bodyLine == "." {
+						break
+					}
+				}
+				// Reject data termination with 554
+				_, _ = conn.Write([]byte("554 5.7.1 Transaction failed / rejected by policy\r\n"))
+				return
+			}
+		}
+	}()
+
+	host, portStr, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
+	var port int
+	_, _ = fmt.Sscanf(portStr, "%d", &port)
+
+	cfg := SMTPConfig{
+		Host:     host,
+		Port:     port,
+		Username: "user",
+		Password: "pass",
+		From:     "sender@test.com",
+		Security: SecurityNone,
+	}
+
+	sender := NewSMTPSender(cfg)
+	err = sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+	if err == nil {
+		t.Fatalf("expected error on SMTP DATA termination failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "close data writer") {
+		t.Errorf("expected error message to contain 'close data writer', got: %v", err)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -147,10 +147,10 @@ func (s *Scheduler) pollFeeds(ctx context.Context) error {
 			}(f)
 		default:
 			// Worker pool is full; release in-flight state and skip for this poll interval
-			s.log.Warn("Worker pool full, postponing feed crawl", "feed_id", f.ID, "title", f.Title)
 			s.inFlightMu.Lock()
 			delete(s.inFlight, f.ID)
 			s.inFlightMu.Unlock() // --- no lock held below this line ---
+			s.log.Warn("Worker pool full, postponing feed crawl", "feed_id", f.ID, "title", f.Title)
 		}
 	}
 
@@ -186,7 +186,7 @@ func (s *Scheduler) processFeed(ctx context.Context, feed *types.Feed) {
 
 	if crawlErr != nil {
 		// Log crawl error
-		s.log.Error("Crawl failed", "url", feed.URL, "err", crawlErr)
+		s.log.Error("Crawl failed", "feed_id", feed.ID, "url", crawler.SanitizeURL(feed.URL), "err", crawlErr)
 
 		// Implement exponential backoff
 		feed.BackoffFactor = min(feed.BackoffFactor*1.5, 24.0)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -106,6 +106,10 @@ func (s *Scheduler) pollFeeds(ctx context.Context) error {
 		return fmt.Errorf("scheduler: list due feeds: %w", err)
 	}
 
+	if len(feeds) > 0 {
+		s.log.Debug("Polled due feeds", "count", len(feeds))
+	}
+
 	// Semaphore to bound concurrency
 	sem := make(chan struct{}, s.cfg.MaxWorkers)
 
@@ -121,6 +125,7 @@ func (s *Scheduler) pollFeeds(ctx context.Context) error {
 		s.inFlightMu.Lock()
 		if s.inFlight[f.ID] {
 			s.inFlightMu.Unlock()
+			s.log.Debug("Feed crawl already in flight, skipping poll", "feed_id", f.ID, "title", f.Title)
 			continue
 		}
 		s.inFlight[f.ID] = true
@@ -142,6 +147,7 @@ func (s *Scheduler) pollFeeds(ctx context.Context) error {
 			}(f)
 		default:
 			// Worker pool is full; release in-flight state and skip for this poll interval
+			s.log.Warn("Worker pool full, postponing feed crawl", "feed_id", f.ID, "title", f.Title)
 			s.inFlightMu.Lock()
 			delete(s.inFlight, f.ID)
 			s.inFlightMu.Unlock() // --- no lock held below this line ---

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -119,8 +119,8 @@ func TestSchedulerHappyPath(t *testing.T) {
 	ctrl := makeMockServer(t)
 	defer ctrl.server.Close()
 
-	cr := crawler.NewCrawler(ctrl.server.Client())
-	ex := extractor.NewExtractor(ctrl.server.Client())
+	cr := crawler.NewCrawler(ctrl.server.Client(), slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(ctrl.server.Client(), slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	s := New(repo, cr, ex, sa, Config{
 		PollInterval: 5 * time.Millisecond,
@@ -208,8 +208,8 @@ func TestSchedulerExtractionStrategiesAndFailures(t *testing.T) {
 	ctrl := makeMockServer(t)
 	defer ctrl.server.Close()
 
-	cr := crawler.NewCrawler(ctrl.server.Client())
-	ex := extractor.NewExtractor(ctrl.server.Client())
+	cr := crawler.NewCrawler(ctrl.server.Client(), slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(ctrl.server.Client(), slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	s := New(repo, cr, ex, sa, Config{}, nil)
 
@@ -307,8 +307,8 @@ func TestSchedulerNotModified(t *testing.T) {
 	ctrl := makeMockServer(t)
 	defer ctrl.server.Close()
 
-	cr := crawler.NewCrawler(ctrl.server.Client())
-	ex := extractor.NewExtractor(ctrl.server.Client())
+	cr := crawler.NewCrawler(ctrl.server.Client(), slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(ctrl.server.Client(), slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	s := New(repo, cr, ex, sa, Config{}, nil)
 
@@ -360,8 +360,8 @@ func TestSchedulerCrawlErrorsAndBackoff(t *testing.T) {
 	ctrl := makeMockServer(t)
 	defer ctrl.server.Close()
 
-	cr := crawler.NewCrawler(ctrl.server.Client())
-	ex := extractor.NewExtractor(ctrl.server.Client())
+	cr := crawler.NewCrawler(ctrl.server.Client(), slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(ctrl.server.Client(), slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	s := New(repo, cr, ex, sa, Config{}, nil)
 
@@ -455,8 +455,8 @@ func TestSchedulerNoSubscribers(t *testing.T) {
 	ctrl := makeMockServer(t)
 	defer ctrl.server.Close()
 
-	cr := crawler.NewCrawler(ctrl.server.Client())
-	ex := extractor.NewExtractor(ctrl.server.Client())
+	cr := crawler.NewCrawler(ctrl.server.Client(), slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(ctrl.server.Client(), slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	s := New(repo, cr, ex, sa, Config{}, nil)
 
@@ -494,8 +494,8 @@ func TestSchedulerStartStop(t *testing.T) {
 	repo := setupTestDB(t)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cr := crawler.NewCrawler(nil)
-	ex := extractor.NewExtractor(nil)
+	cr := crawler.NewCrawler(nil, slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(nil, slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	s := New(repo, cr, ex, sa, Config{
 		PollInterval: 2 * time.Millisecond,
@@ -603,8 +603,8 @@ func TestSchedulerDBErrorsExtended(t *testing.T) {
 	ctrl := makeMockServer(t)
 	defer ctrl.server.Close()
 
-	cr := crawler.NewCrawler(ctrl.server.Client())
-	ex := extractor.NewExtractor(ctrl.server.Client())
+	cr := crawler.NewCrawler(ctrl.server.Client(), slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(ctrl.server.Client(), slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 
 	// Test UpdateFeed fails on crawl failure

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -40,8 +40,8 @@ func setupTestDB(t *testing.T) *database.Repository {
 
 func makeTestServer(t *testing.T, repo *database.Repository) (*Server, *httptest.Server) {
 	t.Helper()
-	cr := crawler.NewCrawler(nil)
-	ex := extractor.NewExtractor(nil)
+	cr := crawler.NewCrawler(nil, slog.New(slog.DiscardHandler))
+	ex := extractor.NewExtractor(nil, slog.New(slog.DiscardHandler))
 	sa := sanitizer.NewSanitizer(600)
 	sched := scheduler.New(repo, cr, ex, sa, scheduler.Config{}, nil)
 
@@ -432,8 +432,8 @@ func TestServerControlActions(t *testing.T) {
 		underlying: mc.Transport,
 		targetHost: mockServer.Listener.Addr().String(),
 	}
-	s.crawler = crawler.NewCrawler(mc)
-	s.extractor = extractor.NewExtractor(mc)
+	s.crawler = crawler.NewCrawler(mc, slog.New(slog.DiscardHandler))
+	s.extractor = extractor.NewExtractor(mc, slog.New(slog.DiscardHandler))
 
 	feed := &types.Feed{
 		Title:              "Crawl Feed",


### PR DESCRIPTION
## Summary

Add structured `slog` debug and info logging across the crawling, parsing, and mail delivery subsystems to make feed fetches, HTML article extraction, polling state transitions, and SMTP/sendmail deliveries fully traceable end to end.

Closes #119

## Changes

- `GEMINI.md`: Document structured logging standards in project guidelines.
- `internal/crawler/crawler.go`: Accept optional `*slog.Logger` in `NewCrawler` constructor and add debug logging for feed fetch start/end, HTTP response status, cache hits, parse success/failure, and errors.
- `internal/extractor/extractor.go`: Accept optional `*slog.Logger` in `NewExtractor` constructor and add debug logging for article extraction start/end, strategy, selector match, and error reasons.
- `internal/scheduler/scheduler.go`: Add debug logging for due feed polling count, skipping in-flight crawls, and worker pool queueing decisions.
- `internal/notifier/notifier.go`: Accept optional `*slog.Logger` in `NewSMTPSender` and `NewSendmailSender` constructors and add debug logging for SMTP/sendmail connection lifecycle, STARTTLS, auth, and message send.

## Impact

No breaking API changes; `NewCrawler`, `NewExtractor`, `NewSMTPSender`, and `NewSendmailSender` accept optional variadic `*slog.Logger` parameters defaulting to `slog.Default()` with appropriate component tags.

## Test Plan

- Ran `go test -race ./internal/crawler/... ./internal/extractor/... ./internal/scheduler/... ./internal/outbox/... ./internal/notifier/...` (all passed).
- Ran `go vet ./...` (passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability**
  * Added structured logging across crawling, content extraction, email delivery, and feed scheduling.
  * Logs now provide clearer visibility into request outcomes, processing milestones, failures, retries, and delivery status.
  * Added diagnostics for skipped or postponed feed crawls when concurrency limits are reached.
* **Documentation**
  * Documented consistent logging standards and severity guidance for system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->