### PR TITLE
fix: reuse SMTP connections to avoid login-rate limits

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -10,6 +10,7 @@ import (
 	"net/smtp"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -37,13 +38,33 @@ type Sender interface {
 	Send(ctx context.Context, subject string, body string, recipients []string) error
 }
 
-// SMTPSender implements email dispatching via SMTP.
+// defaultSMTPOpTimeout bounds every SMTP command (including the initial
+// connect/greeting/STARTTLS/Auth sequence) so a black-holed or silent server
+// cannot hang the shared connection indefinitely.
+const defaultSMTPOpTimeout = 30 * time.Second
+
+// SMTPSender implements email dispatching via SMTP, reusing a single
+// authenticated connection across calls to avoid tripping provider login-rate
+// limits (e.g. Gmail's "too many logins").
 type SMTPSender struct {
 	cfg SMTPConfig
 	log *slog.Logger
+
+	// opTimeout bounds every SMTP operation. Unexported and directly
+	// settable by same-package tests so hung-connection tests don't need
+	// to wait out the real default.
+	opTimeout time.Duration
+
+	mu sync.Mutex
+	// conn is the raw dial-time connection, kept separately from client
+	// because *smtp.Client does not expose it and STARTTLS wraps it in a
+	// *tls.Conn — SetDeadline on this reference still bounds the wrapped
+	// connection's I/O.
+	conn   net.Conn
+	client *smtp.Client
 }
 
-// NewSMTPSender creates a new SMTPSender with optional logger.
+// NewSMTPSender creates a new SMTPSender with an optional logger.
 func NewSMTPSender(cfg SMTPConfig, log ...*slog.Logger) *SMTPSender {
 	var l *slog.Logger
 	if len(log) > 0 && log[0] != nil {
@@ -51,28 +72,24 @@ func NewSMTPSender(cfg SMTPConfig, log ...*slog.Logger) *SMTPSender {
 	} else {
 		l = slog.Default().With("component", "notifier")
 	}
-	return &SMTPSender{cfg: cfg, log: l}
+	return &SMTPSender{cfg: cfg, log: l, opTimeout: defaultSMTPOpTimeout}
 }
 
-// Send dispatches an HTML email to recipients via SMTP.
-func (s *SMTPSender) Send(ctx context.Context, subject string, body string, recipients []string) error {
-	if len(recipients) == 0 {
-		return fmt.Errorf("notifier: smtp: no recipients specified")
+// logger returns s.log, falling back to a default so struct literals built
+// without NewSMTPSender (as some tests do) stay nil-safe.
+func (s *SMTPSender) logger() *slog.Logger {
+	if s.log != nil {
+		return s.log
 	}
+	return slog.Default().With("component", "notifier")
+}
 
-	log := s.log
-	if log == nil {
-		log = slog.Default().With("component", "notifier")
-	}
-
-	cleanedSubject := CleanHeader(subject)
-	log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", cleanedSubject)
-
-	msg := buildMessage(s.cfg.From, recipients, cleanedSubject, body)
-
+// connect dials, greets, STARTTLSes, and authenticates a fresh connection.
+// Callers must hold s.mu.
+func (s *SMTPSender) connect(ctx context.Context) (*smtp.Client, error) {
+	log := s.logger()
 	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 
-	// Dial connection
 	var conn net.Conn
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	var err error
@@ -82,77 +99,162 @@ func (s *SMTPSender) Send(ctx context.Context, subject string, body string, reci
 			ServerName: s.cfg.Host,
 			MinVersion: tls.VersionTLS12,
 		}
-		conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+		tlsDialer := &tls.Dialer{NetDialer: dialer, Config: tlsConfig}
+		conn, err = tlsDialer.DialContext(ctx, "tcp", addr)
 	} else {
 		conn, err = dialer.DialContext(ctx, "tcp", addr)
 	}
 	if err != nil {
 		log.Debug("SMTP connection failed", "addr", addr, "security", s.cfg.Security, "err", err)
-		return fmt.Errorf("notifier: smtp dial failed: %w", err)
+		return nil, fmt.Errorf("notifier: smtp dial failed: %w", err)
 	}
-	defer func() { _ = conn.Close() }()
+
+	// Bound the greeting read + STARTTLS + Auth sequence: none of these
+	// have a deadline beyond the TCP handshake otherwise, so a server that
+	// accepts the connection but stays silent would hang forever.
+	if err := conn.SetDeadline(time.Now().Add(s.opTimeout)); err != nil {
+		_ = conn.Close()
+		log.Debug("Failed to set SMTP connect deadline", "addr", addr, "err", err)
+		return nil, fmt.Errorf("notifier: set connect deadline: %w", err)
+	}
 
 	client, err := smtp.NewClient(conn, s.cfg.Host)
 	if err != nil {
+		_ = conn.Close()
 		log.Debug("Failed creating SMTP client", "host", s.cfg.Host, "err", err)
-		return fmt.Errorf("notifier: create smtp client: %w", err)
+		return nil, fmt.Errorf("notifier: create smtp client: %w", err)
 	}
-	defer func() { _ = client.Close() }()
 
-	// STARTTLS handshake
 	if s.cfg.Security == SecuritySTARTTLS {
 		tlsConfig := &tls.Config{
 			ServerName: s.cfg.Host,
 			MinVersion: tls.VersionTLS12,
 		}
 		if err := client.StartTLS(tlsConfig); err != nil {
+			_ = client.Close()
 			log.Debug("SMTP STARTTLS failed", "host", s.cfg.Host, "err", err)
-			return fmt.Errorf("notifier: starttls failed: %w", err)
+			return nil, fmt.Errorf("notifier: starttls failed: %w", err)
 		}
 	}
 
-	// Authenticate
 	if s.cfg.Username != "" {
 		auth := smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
 		if err := client.Auth(auth); err != nil {
+			_ = client.Close()
 			log.Debug("SMTP authentication failed", "user", s.cfg.Username, "err", err)
-			return fmt.Errorf("notifier: authentication failed: %w", err)
+			return nil, fmt.Errorf("notifier: authentication failed: %w", err)
 		}
 	}
 
-	// Set sender and recipients
+	log.Debug("SMTP connection established", "addr", addr, "security", s.cfg.Security)
+	s.conn = conn
+	s.client = client
+	return client, nil
+}
+
+// closeCached discards the cached connection. Once any operation on it times
+// out or errors, the underlying tls.Conn (if STARTTLS was used) is
+// permanently unusable per crypto/tls's own semantics, so it must never be
+// reused after an error — always redial instead of retrying in place.
+// Callers must hold s.mu.
+func (s *SMTPSender) closeCached() {
+	if s.client != nil {
+		_ = s.client.Close()
+	}
+	s.client = nil
+	s.conn = nil
+}
+
+// getClient returns a live, authenticated client, reusing the cached one
+// after a liveness check or dialing fresh otherwise. Callers must hold s.mu.
+func (s *SMTPSender) getClient(ctx context.Context) (*smtp.Client, error) {
+	if s.client != nil {
+		if err := s.conn.SetDeadline(time.Now().Add(s.opTimeout)); err == nil {
+			if err := s.client.Noop(); err == nil {
+				s.logger().Debug("Reusing cached SMTP connection")
+				return s.client, nil
+			}
+		}
+		s.logger().Debug("Cached SMTP connection stale, reconnecting")
+		s.closeCached()
+	}
+	return s.connect(ctx)
+}
+
+// Send dispatches an HTML email to recipients via SMTP, reusing a cached
+// connection across calls when possible.
+func (s *SMTPSender) Send(ctx context.Context, subject string, body string, recipients []string) error {
+	if len(recipients) == 0 {
+		return fmt.Errorf("notifier: smtp: no recipients specified")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	log := s.logger()
+	cleanedSubject := CleanHeader(subject)
+	log.Debug("Starting SMTP email delivery", "host", s.cfg.Host, "port", s.cfg.Port, "recipients_count", len(recipients), "subject", cleanedSubject)
+
+	msg := buildMessage(s.cfg.From, recipients, cleanedSubject, body)
+
+	// Holding s.mu across blocking network I/O below is a deliberate
+	// exception to this project's "never hold a mutex during I/O" rule
+	// (GEMINI.md): the whole point of this type is that all sends share
+	// one physical SMTP connection/session, and SMTP is a single-stream
+	// protocol — interleaving Mail/Rcpt/Data from two callers on the same
+	// connection would corrupt the session, not just contend on a lock.
+	// TestSMTPSenderConcurrentSendsSerialize proves this is load-bearing,
+	// not incidental.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	client, err := s.getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := s.conn.SetDeadline(time.Now().Add(s.opTimeout)); err != nil {
+		return s.discardAndFail("set send deadline", err)
+	}
+
 	if err := client.Mail(s.cfg.From); err != nil {
-		log.Debug("SMTP MAIL FROM command failed", "from", s.cfg.From, "err", err)
-		return fmt.Errorf("notifier: set mail from: %w", err)
+		return s.discardAndFail("set mail from", err)
 	}
 
 	for _, to := range recipients {
 		if err := client.Rcpt(to); err != nil {
-			log.Debug("SMTP RCPT TO command failed", "to", to, "err", err)
-			return fmt.Errorf("notifier: set rcpt to %s: %w", to, err)
+			return s.discardAndFail(fmt.Sprintf("set rcpt to %s", to), err)
 		}
 	}
 
-	// Write body
 	w, err := client.Data()
 	if err != nil {
-		log.Debug("SMTP DATA command failed", "err", err)
-		return fmt.Errorf("notifier: open data writer: %w", err)
+		return s.discardAndFail("open data writer", err)
 	}
 
 	if _, err := w.Write(msg); err != nil {
-		_ = w.Close()
-		log.Debug("SMTP message data write failed", "err", err)
-		return fmt.Errorf("notifier: write message data: %w", err)
+		return s.discardAndFail("write message data", err)
 	}
 
 	if err := w.Close(); err != nil {
-		log.Debug("SMTP DATA termination failed", "err", err)
-		return fmt.Errorf("notifier: close data writer: %w", err)
+		return s.discardAndFail("close data writer", err)
 	}
 
 	log.Debug("SMTP email delivered successfully", "recipients_count", len(recipients), "bytes", len(msg))
 	return nil
+}
+
+// discardAndFail discards the cached connection (any error at this point
+// means it must not be reused) and wraps err with op for the caller. Callers
+// must hold s.mu.
+func (s *SMTPSender) discardAndFail(op string, err error) error {
+	s.logger().Debug("SMTP operation failed, discarding connection", "op", op, "err", err)
+	s.closeCached()
+	return fmt.Errorf("notifier: %s: %w", op, err)
 }
 
 // SendmailSender implements email dispatching via a local system sendmail command.

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -99,6 +99,9 @@ type mockSMTPServer struct {
 	// rejectAuth, when set, makes every AUTH PLAIN fail with a permanent
 	// error instead of succeeding.
 	rejectAuth atomic.Bool
+	// rejectMailFrom, when set, makes every MAIL FROM fail with a
+	// permanent error instead of succeeding.
+	rejectMailFrom atomic.Bool
 
 	mu    sync.Mutex
 	conns []*mockConn
@@ -225,9 +228,12 @@ func (srv *mockSMTPServer) handleConn(mc *mockConn) {
 			srv.authCount.Add(1)
 			_, _ = c.Write([]byte("235 2.7.0 Authentication successful\r\n"))
 		case strings.HasPrefix(cmd, "MAIL FROM:"):
-			if !authed {
+			switch {
+			case !authed:
 				_, _ = c.Write([]byte("530 5.7.0 Must issue a STARTTLS or AUTH command first\r\n"))
-			} else {
+			case srv.rejectMailFrom.Load():
+				_, _ = c.Write([]byte("451 4.7.1 Sender rejected\r\n"))
+			default:
 				_, _ = c.Write([]byte("250 2.1.0 Ok\r\n"))
 			}
 		case strings.HasPrefix(cmd, "RCPT TO:"):
@@ -628,6 +634,30 @@ func TestSMTPSenderRcptRejected(t *testing.T) {
 	}
 }
 
+// TestSMTPSenderMailFromRejected proves a MAIL FROM rejection (the earliest
+// point in the per-message transaction where the server can reject) also
+// discards the cached connection via discardAndFail, same as a later-stage
+// RCPT rejection.
+func TestSMTPSenderMailFromRejected(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	srv.rejectMailFrom.Store(true)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+	if err == nil {
+		t.Fatal("expected an error for a rejected MAIL FROM, got nil")
+	}
+
+	srv.rejectMailFrom.Store(false)
+	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("send after rejection failed: %v", err)
+	}
+
+	if got := srv.authCount.Load(); got != 2 {
+		t.Errorf("expected 2 AUTH (rejection discarded the first connection, forcing a redial), got %d", got)
+	}
+}
+
 // TestSMTPSenderAuthRejected proves a connect()-phase Auth failure returns a
 // clean error with nothing cached, and does not corrupt state for a later
 // send against a healthy configuration.
@@ -647,5 +677,74 @@ func TestSMTPSenderAuthRejected(t *testing.T) {
 	srv.rejectAuth.Store(false)
 	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
 		t.Fatalf("send after auth rejection cleared failed: %v", err)
+	}
+}
+
+// TestSMTPSenderCanceledContext proves Send() bails out immediately on an
+// already-canceled context instead of proceeding to reuse (or dial) a
+// connection regardless — including on a warm cache, where no SMTP call in
+// the reuse path otherwise takes a context at all.
+func TestSMTPSenderCanceledContext(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	// Warm the cache with one successful send first.
+	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("warm-up send failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := sender.Send(ctx, "Hello again", "<p>Test</p>", []string{"recipient@test.com"}); err == nil {
+		t.Fatal("expected an error for an already-canceled context, got nil")
+	}
+
+	// The canceled-context send must not have touched the connection at
+	// all: AUTH count stays at 1, and the next send with a live context
+	// reuses the still-cached, still-good connection.
+	if got := srv.authCount.Load(); got != 1 {
+		t.Errorf("expected AUTH count to stay at 1 (canceled send should not touch the connection), got %d", got)
+	}
+	if err := sender.Send(context.Background(), "Hello once more", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("send after canceled-context send failed: %v", err)
+	}
+	if got := srv.authCount.Load(); got != 1 {
+		t.Errorf("expected AUTH count to remain 1 (cache still valid), got %d", got)
+	}
+}
+
+// TestSMTPSenderCanceledContextWhileWaitingForLock proves the second,
+// post-lock ctx.Err() check in Send() is reachable and correct: a context
+// that is still live when Send() is called, but gets canceled while Send()
+// is blocked waiting to acquire s.mu, must still bail out once the lock is
+// acquired — without ever attempting to contact the server.
+func TestSMTPSenderCanceledContextWhileWaitingForLock(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Hold the lock ourselves (simulating another in-flight Send()), so
+	// this call's pre-lock check sees a live ctx and then blocks on
+	// s.mu.Lock() — exactly the window the post-lock check exists for.
+	sender.mu.Lock()
+	unlocked := make(chan struct{})
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+		sender.mu.Unlock()
+		close(unlocked)
+	}()
+
+	err := sender.Send(ctx, "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+	<-unlocked
+
+	if err == nil {
+		t.Fatal("expected an error for a context canceled while waiting on the lock")
+	}
+	if got := srv.authCount.Load(); got != 0 {
+		t.Errorf("expected no AUTH attempt (post-lock ctx check must bail before touching the connection), got %d", got)
 	}
 }

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -10,7 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestCleanHeader(t *testing.T) {
@@ -77,8 +79,52 @@ func TestSendmailSender(t *testing.T) {
 	}
 }
 
-// startMockSMTPServer starts a local TCP server that simulates basic SMTP exchanges.
-func startMockSMTPServer(t *testing.T) (string, func()) {
+// mockConn pairs an accepted server-side connection with a per-connection
+// silence flag, so a test can make exactly one connection stop responding
+// (simulating a stale/hung cached connection) without affecting any other
+// connection accepted before or after it.
+type mockConn struct {
+	conn     net.Conn
+	silenced atomic.Bool
+}
+
+// mockSMTPServer simulates basic SMTP exchanges for tests. It tracks AUTH
+// invocations and each accepted server-side connection so tests can force-
+// close or silence a specific connection to exercise SMTPSender's reconnect
+// and deadline handling.
+type mockSMTPServer struct {
+	addr      string
+	authCount atomic.Int64
+
+	// rejectAuth, when set, makes every AUTH PLAIN fail with a permanent
+	// error instead of succeeding.
+	rejectAuth atomic.Bool
+
+	mu    sync.Mutex
+	conns []*mockConn
+	// rejectRcpt, when non-empty, makes RCPT TO for exactly this address
+	// fail with a permanent error instead of succeeding. Guarded by mu
+	// (read/written far less often than conns, sharing the lock is fine).
+	rejectRcpt string
+
+	wg sync.WaitGroup
+}
+
+func (srv *mockSMTPServer) setRejectRcpt(addr string) {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	srv.rejectRcpt = addr
+}
+
+func (srv *mockSMTPServer) getRejectRcpt() string {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	return srv.rejectRcpt
+}
+
+// startMockSMTPServer starts a local TCP server that simulates basic SMTP
+// exchanges.
+func startMockSMTPServer(t *testing.T) *mockSMTPServer {
 	t.Helper()
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -86,36 +132,63 @@ func startMockSMTPServer(t *testing.T) (string, func()) {
 		t.Fatalf("failed to listen: %v", err)
 	}
 
-	shutdown := make(chan struct{})
-	var serverWg sync.WaitGroup
+	srv := &mockSMTPServer{addr: l.Addr().String()}
 
-	serverWg.Go(func() {
+	srv.wg.Go(func() {
 		for {
 			conn, err := l.Accept()
 			if err != nil {
-				select {
-				case <-shutdown:
-					return
-				default:
-					t.Errorf("SMTP accept error: %v", err)
-					return
-				}
+				return
 			}
 
-			go handleSMTPConn(conn)
+			mc := &mockConn{conn: conn}
+			srv.mu.Lock()
+			srv.conns = append(srv.conns, mc)
+			srv.mu.Unlock()
+
+			srv.wg.Go(func() {
+				srv.handleConn(mc)
+			})
 		}
 	})
 
-	closeFn := func() {
-		close(shutdown)
+	t.Cleanup(func() {
 		_ = l.Close()
-		serverWg.Wait()
-	}
+		srv.mu.Lock()
+		for _, mc := range srv.conns {
+			_ = mc.conn.Close()
+		}
+		srv.mu.Unlock()
+		srv.wg.Wait()
+	})
 
-	return l.Addr().String(), closeFn
+	return srv
 }
 
-func handleSMTPConn(c net.Conn) {
+// connAt returns the i'th server-side connection accepted so far, or nil.
+func (srv *mockSMTPServer) connAt(i int) net.Conn {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if i >= len(srv.conns) {
+		return nil
+	}
+	return srv.conns[i].conn
+}
+
+// silenceConnAt makes the i'th accepted connection stop responding to any
+// further commands, without closing the socket — simulating a server that
+// goes silent mid-session. Only that specific connection is affected;
+// connections accepted before or after it behave normally.
+func (srv *mockSMTPServer) silenceConnAt(i int) {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if i < len(srv.conns) {
+		srv.conns[i].silenced.Store(true)
+	}
+}
+
+func (srv *mockSMTPServer) handleConn(mc *mockConn) {
+	c := mc.conn
 	defer func() { _ = c.Close() }()
 
 	reader := bufio.NewReader(c)
@@ -132,21 +205,40 @@ func handleSMTPConn(c net.Conn) {
 			return
 		}
 
+		// Once armed, stop responding to anything further on this
+		// specific connection, simulating a server that goes silent
+		// mid-session without closing the socket.
+		if mc.silenced.Load() {
+			continue
+		}
+
 		cmd := strings.ToUpper(line)
-		if strings.HasPrefix(cmd, "EHLO") || strings.HasPrefix(cmd, "HELO") {
+		switch {
+		case strings.HasPrefix(cmd, "EHLO") || strings.HasPrefix(cmd, "HELO"):
 			_, _ = c.Write([]byte("250-smtp.mock.test Hello\r\n250 AUTH PLAIN\r\n"))
-		} else if strings.HasPrefix(cmd, "AUTH PLAIN") {
+		case strings.HasPrefix(cmd, "AUTH PLAIN"):
+			if srv.rejectAuth.Load() {
+				_, _ = c.Write([]byte("535 5.7.8 Authentication credentials invalid\r\n"))
+				break
+			}
 			authed = true
+			srv.authCount.Add(1)
 			_, _ = c.Write([]byte("235 2.7.0 Authentication successful\r\n"))
-		} else if strings.HasPrefix(cmd, "MAIL FROM:") {
+		case strings.HasPrefix(cmd, "MAIL FROM:"):
 			if !authed {
 				_, _ = c.Write([]byte("530 5.7.0 Must issue a STARTTLS or AUTH command first\r\n"))
 			} else {
 				_, _ = c.Write([]byte("250 2.1.0 Ok\r\n"))
 			}
-		} else if strings.HasPrefix(cmd, "RCPT TO:") {
-			_, _ = c.Write([]byte("250 2.1.5 Ok\r\n"))
-		} else if cmd == "DATA" {
+		case strings.HasPrefix(cmd, "RCPT TO:"):
+			if reject := srv.getRejectRcpt(); reject != "" && strings.Contains(cmd, strings.ToUpper(reject)) {
+				_, _ = c.Write([]byte("550 5.1.1 User unknown\r\n"))
+			} else {
+				_, _ = c.Write([]byte("250 2.1.5 Ok\r\n"))
+			}
+		case cmd == "NOOP":
+			_, _ = c.Write([]byte("250 2.0.0 Ok\r\n"))
+		case cmd == "DATA":
 			_, _ = c.Write([]byte("354 Start mail input; end with <CR><LF>.<CR><LF>\r\n"))
 			// Read mail body until "."
 			for {
@@ -159,18 +251,57 @@ func handleSMTPConn(c net.Conn) {
 				}
 			}
 			_, _ = c.Write([]byte("250 2.0.0 Ok: queued\r\n"))
-		} else if cmd == "QUIT" {
+		case cmd == "QUIT":
 			_, _ = c.Write([]byte("221 2.0.0 Bye\r\n"))
 			return
-		} else {
+		default:
 			_, _ = c.Write([]byte("500 5.5.1 Command unrecognized\r\n"))
 		}
 	}
 }
 
-func TestSMTPSenderHappyPath(t *testing.T) {
-	addr, closeFn := startMockSMTPServer(t)
-	defer closeFn()
+// startSilentListener accepts TCP connections but never writes a byte,
+// simulating a server that accepts the connection but never sends the SMTP
+// greeting — used to test connect()'s own deadline bound.
+func startSilentListener(t *testing.T) string {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	var mu sync.Mutex
+	var conns []net.Conn
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
+		}
+	})
+
+	t.Cleanup(func() {
+		_ = l.Close()
+		mu.Lock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		mu.Unlock()
+		wg.Wait()
+	})
+
+	return l.Addr().String()
+}
+
+func newTestSMTPSender(t *testing.T, addr string) *SMTPSender {
+	t.Helper()
 
 	host, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -191,22 +322,26 @@ func TestSMTPSenderHappyPath(t *testing.T) {
 		Security: SecurityNone,
 	}
 
-	sender := NewSMTPSender(cfg)
-	err = sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+	return NewSMTPSender(cfg)
+}
+
+func TestSMTPSenderHappyPath(t *testing.T) {
+	srv := startMockSMTPServer(t)
+
+	sender := newTestSMTPSender(t, srv.addr)
+	err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
 	if err != nil {
 		t.Fatalf("SMTP send failed: %v", err)
 	}
 }
 
 func TestNilLoggerGuards(t *testing.T) {
-	addr, closeFn := startMockSMTPServer(t)
-	defer closeFn()
+	srv := startMockSMTPServer(t)
 
-	host, portStr, err := net.SplitHostPort(addr)
+	host, portStr, err := net.SplitHostPort(srv.addr)
 	if err != nil {
 		t.Fatalf("failed to split host/port: %v", err)
 	}
-
 	var port int
 	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
 		t.Fatalf("failed to parse port: %v", err)
@@ -222,7 +357,8 @@ func TestNilLoggerGuards(t *testing.T) {
 			From:     "sender@test.com",
 			Security: SecurityNone,
 		},
-		log: nil,
+		log:       nil,
+		opTimeout: defaultSMTPOpTimeout,
 	}
 
 	if err := smtpSender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
@@ -323,5 +459,193 @@ func TestSMTPSenderDataCloseError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "close data writer") {
 		t.Errorf("expected error message to contain 'close data writer', got: %v", err)
+	}
+}
+
+// TestSMTPSenderConnectionReuse proves consecutive Send() calls reuse the
+// cached connection instead of dialing and authenticating fresh each time.
+func TestSMTPSenderConnectionReuse(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	for i := range 3 {
+		if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+			t.Fatalf("send %d failed: %v", i, err)
+		}
+	}
+
+	if got := srv.authCount.Load(); got != 1 {
+		t.Errorf("expected 1 AUTH across 3 sequential sends, got %d", got)
+	}
+}
+
+// TestSMTPSenderConcurrentSendsSerialize proves concurrent Send() calls are
+// serialized onto the single cached connection without protocol corruption,
+// and still only authenticate once.
+func TestSMTPSenderConcurrentSendsSerialize(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	const n = 10
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := range n {
+		wg.Go(func() {
+			errs[i] = sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("send %d failed: %v", i, err)
+		}
+	}
+
+	if got := srv.authCount.Load(); got != 1 {
+		t.Errorf("expected 1 AUTH across %d concurrent sends, got %d", n, got)
+	}
+}
+
+// TestSMTPSenderReconnectAfterStaleConnection proves that when the cached
+// connection dies server-side, the next Send() detects it and redials.
+func TestSMTPSenderReconnectAfterStaleConnection(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("first send failed: %v", err)
+	}
+
+	conn := srv.connAt(0)
+	if conn == nil {
+		t.Fatal("expected a server-side connection to have been accepted")
+	}
+	_ = conn.Close()
+
+	if err := sender.Send(context.Background(), "Hello again", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("second send failed after forced disconnect: %v", err)
+	}
+
+	if got := srv.authCount.Load(); got != 2 {
+		t.Errorf("expected 2 AUTH (one per physical connection), got %d", got)
+	}
+}
+
+// TestSMTPSenderHungConnectBound proves connect() itself is bounded by
+// opTimeout when the server accepts the TCP connection but never sends the
+// greeting.
+func TestSMTPSenderHungConnectBound(t *testing.T) {
+	addr := startSilentListener(t)
+	sender := newTestSMTPSender(t, addr)
+	sender.opTimeout = 100 * time.Millisecond
+
+	start := time.Now()
+	err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a silent server, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("expected Send to bound by ~opTimeout, took %v", elapsed)
+	}
+
+	// A subsequent send against a healthy server must still succeed.
+	srv := startMockSMTPServer(t)
+	sender2 := newTestSMTPSender(t, srv.addr)
+	if err := sender2.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("send against healthy server failed: %v", err)
+	}
+}
+
+// TestSMTPSenderHungReuseBound proves that if the cached connection goes
+// silent mid-session (without closing the socket), the Noop liveness check
+// in getClient catches it — bounded by opTimeout, not hanging — and Send()
+// transparently discards the stale connection and redials within the same
+// call, so the send still succeeds rather than surfacing an error to the
+// caller. This is a better outcome than a bare bounded error: the discard-
+// on-any-error path is still the deeper safety net for staleness the Noop
+// check misses (e.g. a hang mid-transaction, after Noop already succeeded),
+// but the common case of a liveness-checkable stale connection self-heals
+// invisibly.
+func TestSMTPSenderHungReuseBound(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	sender := newTestSMTPSender(t, srv.addr)
+	sender.opTimeout = 100 * time.Millisecond
+
+	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("first send failed: %v", err)
+	}
+
+	// Silence only the one connection the first Send() established and
+	// cached — a new connection dialed later must NOT inherit this.
+	srv.silenceConnAt(0)
+
+	start := time.Now()
+	err := sender.Send(context.Background(), "Hello again", "<p>Test</p>", []string{"recipient@test.com"})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected transparent redial to succeed despite the stale cached connection, got: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("expected the stale-connection detection + redial to bound by ~opTimeout, took %v", elapsed)
+	}
+	if elapsed < sender.opTimeout {
+		t.Errorf("expected elapsed time to include the Noop liveness-check timeout (~%v), got %v", sender.opTimeout, elapsed)
+	}
+
+	if got := srv.authCount.Load(); got != 2 {
+		t.Errorf("expected 2 AUTH (initial connection + redial after detecting staleness), got %d", got)
+	}
+}
+
+// TestSMTPSenderRcptRejected proves a mid-transaction SMTP rejection (as
+// opposed to a connection-level failure) still discards the cached
+// connection via discardAndFail, so the next Send() redials rather than
+// reusing a connection left in an undefined transaction state.
+func TestSMTPSenderRcptRejected(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	srv.setRejectRcpt("bad@test.com")
+	sender := newTestSMTPSender(t, srv.addr)
+
+	err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"bad@test.com"})
+	if err == nil {
+		t.Fatal("expected an error for a rejected recipient, got nil")
+	}
+
+	// A later send to a valid recipient must redial cleanly rather than
+	// reuse the connection the rejection left mid-transaction.
+	srv.setRejectRcpt("")
+	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"good@test.com"}); err != nil {
+		t.Fatalf("send after rejection failed: %v", err)
+	}
+
+	if got := srv.authCount.Load(); got != 2 {
+		t.Errorf("expected 2 AUTH (rejection discarded the first connection, forcing a redial), got %d", got)
+	}
+}
+
+// TestSMTPSenderAuthRejected proves a connect()-phase Auth failure returns a
+// clean error with nothing cached, and does not corrupt state for a later
+// send against a healthy configuration.
+func TestSMTPSenderAuthRejected(t *testing.T) {
+	srv := startMockSMTPServer(t)
+	srv.rejectAuth.Store(true)
+	sender := newTestSMTPSender(t, srv.addr)
+
+	err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"})
+	if err == nil {
+		t.Fatal("expected an error for rejected authentication, got nil")
+	}
+	if sender.client != nil {
+		t.Error("expected no client to be cached after a failed Auth")
+	}
+
+	srv.rejectAuth.Store(false)
+	if err := sender.Send(context.Background(), "Hello", "<p>Test</p>", []string{"recipient@test.com"}); err != nil {
+		t.Fatalf("send after auth rejection cleared failed: %v", err)
 	}
 }

--- a/internal/outbox/outbox.go
+++ b/internal/outbox/outbox.go
@@ -20,13 +20,25 @@ type Config struct {
 	PollInterval   time.Duration
 }
 
-// Queue manages background processing of the durable email outbox.
+// Queue manages background processing of the durable email outbox. Delivery
+// is fully sequential within Start's own goroutine — items are drained one
+// at a time (oldest-due-first) rather than fanned out to a goroutine per
+// item, so the shared notifier.Sender only ever sees one caller at a time.
 type Queue struct {
-	repo         *database.Repository
-	sender       notifier.Sender
-	cfg          Config
-	inFlight     map[int64]bool
-	inFlightMu   sync.Mutex
+	repo   *database.Repository
+	sender notifier.Sender
+	cfg    Config
+
+	// mu guards stopped, checked atomically alongside wg.Add in
+	// tryBeginCycle so a Stop() call can never race a new cycle starting:
+	// either tryBeginCycle wins and registers the cycle before Stop sees
+	// it, or Stop sets stopped first and tryBeginCycle refuses to start.
+	// Without this, a fast PollInterval racing an external Stop() call can
+	// call wg.Add concurrently with wg.Wait, which the runtime detects as
+	// WaitGroup misuse and panics on.
+	mu      sync.Mutex
+	stopped bool
+
 	wg           sync.WaitGroup
 	shutdownCh   chan struct{}
 	shutdownOnce sync.Once
@@ -55,10 +67,24 @@ func NewQueue(repo *database.Repository, sender notifier.Sender, cfg Config, log
 		repo:       repo,
 		sender:     sender,
 		cfg:        cfg,
-		inFlight:   make(map[int64]bool),
 		shutdownCh: make(chan struct{}),
 		log:        log,
 	}
+}
+
+// tryBeginCycle atomically checks whether shutdown has been requested and,
+// if not, registers one in-flight processPending cycle with wg. Returns
+// false if Stop has already been called, in which case the caller must not
+// start a new cycle — see the Queue.mu doc comment for why this must be
+// atomic rather than a separate check-then-Add.
+func (q *Queue) tryBeginCycle() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.stopped {
+		return false
+	}
+	q.wg.Add(1)
+	return true
 }
 
 // Start launches the outbox processing loop. It blocks until context is cancelled or Stop is called.
@@ -67,9 +93,19 @@ func (q *Queue) Start(ctx context.Context) error {
 	defer ticker.Stop()
 
 	for {
-		// Process pending items
-		if err := q.processPending(ctx); err != nil {
-			q.log.Error("Processing error", "err", err)
+		// wg is scoped to this one processPending call (not Start's whole
+		// lifetime): Start calls Stop() itself below on ctx.Done(), and by
+		// that point processPending has already returned, so the counter
+		// is back at 0 and Stop()'s Wait() returns immediately — scoping
+		// Add/Done around all of Start instead would self-deadlock, since
+		// Start would be blocked inside its own Stop() call waiting for a
+		// Done() that only fires when Start returns.
+		if q.tryBeginCycle() {
+			err := q.processPending(ctx)
+			q.wg.Done()
+			if err != nil {
+				q.log.Error("Processing error", "err", err)
+			}
 		}
 
 		select {
@@ -86,12 +122,18 @@ func (q *Queue) Start(ctx context.Context) error {
 // Stop gracefully stops the queue processor, waiting for in-flight deliveries to complete.
 func (q *Queue) Stop() {
 	q.shutdownOnce.Do(func() {
+		q.mu.Lock()
+		q.stopped = true
+		q.mu.Unlock()
 		close(q.shutdownCh)
 		q.wg.Wait()
 	})
 }
 
-// processPending queries items ready for delivery and spawns worker goroutines.
+// processPending queries items ready for delivery and delivers them
+// sequentially, oldest-due-first. No goroutines are spawned here: the
+// previous per-item fan-out is what caused a burst of pending items to open
+// N concurrent SMTP connections/logins at once.
 func (q *Queue) processPending(ctx context.Context) error {
 	// Only fetch items where retry count is below limits
 	items, err := q.repo.ListPendingOutboxItems(ctx, time.Now())
@@ -105,25 +147,7 @@ func (q *Queue) processPending(ctx context.Context) error {
 			continue
 		}
 
-		q.inFlightMu.Lock()
-		if q.inFlight[item.ID] {
-			q.inFlightMu.Unlock()
-			continue
-		}
-		q.inFlight[item.ID] = true
-		q.inFlightMu.Unlock()
-
-		q.wg.Add(1)
-		go func(it *types.OutboxItem) {
-			defer q.wg.Done()
-			defer func() {
-				q.inFlightMu.Lock()
-				delete(q.inFlight, it.ID)
-				q.inFlightMu.Unlock()
-			}()
-
-			q.deliverItem(ctx, it)
-		}(item)
+		q.deliverItem(ctx, item)
 	}
 
 	return nil

--- a/internal/outbox/outbox.go
+++ b/internal/outbox/outbox.go
@@ -23,7 +23,10 @@ type Config struct {
 // Queue manages background processing of the durable email outbox. Delivery
 // is fully sequential within Start's own goroutine — items are drained one
 // at a time (oldest-due-first) rather than fanned out to a goroutine per
-// item, so the shared notifier.Sender only ever sees one caller at a time.
+// item, keeping a poll cycle to at most one simultaneous SMTP
+// connection/login regardless of how many items are pending. This is a
+// property of how Queue drains its own batch, not a requirement
+// notifier.Sender itself imposes.
 type Queue struct {
 	repo   *database.Repository
 	sender notifier.Sender
@@ -142,6 +145,15 @@ func (q *Queue) processPending(ctx context.Context) error {
 	}
 
 	for _, item := range items {
+		// Bail out of the batch on a canceled context rather than working
+		// through every remaining item first: since delivery is sequential,
+		// skipping this check would let a cancellation partway through a
+		// large batch cost up to len(items)*opTimeout before Start's loop
+		// can even reach its own ctx.Done() case.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		// Filter out items already hit max retries
 		if item.RetryCount >= q.cfg.MaxRetries {
 			continue

--- a/internal/outbox/outbox.go
+++ b/internal/outbox/outbox.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -106,7 +107,7 @@ func (q *Queue) Start(ctx context.Context) error {
 		if q.tryBeginCycle() {
 			err := q.processPending(ctx)
 			q.wg.Done()
-			if err != nil {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				q.log.Error("Processing error", "err", err)
 			}
 		}

--- a/internal/outbox/outbox_test.go
+++ b/internal/outbox/outbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -755,5 +756,91 @@ func TestOutboxQueueProcessPendingStopsOnCanceledContext(t *testing.T) {
 
 	if got := mock.getCalled(); got != 1 {
 		t.Errorf("expected exactly 1 delivery attempt before bailing on cancellation, got %d", got)
+	}
+}
+
+// recordingHandler is a minimal slog.Handler that captures every record it
+// receives, so tests can assert on log level/content without parsing text
+// output.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *recordingHandler) hasMessageAtLevel(msg string, level slog.Level) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level == level && r.Message == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// TestOutboxQueueNoErrorLogOnContextCancellation proves a context-cancellation
+// mid-batch (processPending returning context.Canceled) is not logged at
+// Error level — that's routine, cancel-driven shutdown, not a genuine
+// processing failure.
+func TestOutboxQueueNoErrorLogOnContextCancellation(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &MockSender{}
+	sender := &cancelAfterFirstSendSender{MockSender: mock, cancel: cancel}
+	handler := &recordingHandler{}
+
+	cfg := Config{
+		MaxRetries:     3,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+		PollInterval:   2 * time.Millisecond,
+	}
+	queue := NewQueue(repo, sender, cfg, slog.New(handler))
+
+	for i := range 3 {
+		item := &types.OutboxItem{
+			Subject:       "Item",
+			Body:          "Body",
+			Recipients:    []string{"user@test.com"},
+			Status:        types.OutboxPending,
+			NextAttemptAt: time.Now().Add(-time.Duration(3-i) * time.Second),
+		}
+		if err := repo.EnqueueOutboxItem(context.Background(), item); err != nil {
+			t.Fatalf("failed to enqueue: %v", err)
+		}
+	}
+
+	// Drive through the real Start loop: item 1's Send() cancels ctx, so
+	// processPending's ctx.Err() check bails on item 2, returning
+	// context.Canceled up into Start's own log-suppression logic.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_ = queue.Start(ctx)
+	})
+	wg.Wait()
+
+	if got := mock.getCalled(); got != 1 {
+		t.Fatalf("expected exactly 1 delivery attempt before Start's loop observed cancellation, got %d", got)
+	}
+	// Scoped to Start's own "Processing error" log call (the one this fix
+	// touches) rather than asserting no Error-level record at all: item 1's
+	// own delivery can independently log an unrelated DB-write error here
+	// (its status-update races the same cancellation), which is pre-existing
+	// deliverItem behavior this PR does not change and is out of scope for
+	// this test's claim.
+	if handler.hasMessageAtLevel("Processing error", slog.LevelError) {
+		t.Error("expected no \"Processing error\" log record for a context-cancellation shutdown")
 	}
 }

--- a/internal/outbox/outbox_test.go
+++ b/internal/outbox/outbox_test.go
@@ -704,3 +704,56 @@ func TestOutboxQueueStopWaitsForInFlightDelivery(t *testing.T) {
 
 	startWg.Wait()
 }
+
+// cancelAfterFirstSendSender wraps a MockSender and cancels the given
+// context after its first Send() call, simulating ctx being canceled
+// partway through a poll cycle's batch.
+type cancelAfterFirstSendSender struct {
+	*MockSender
+	cancel func()
+}
+
+func (s *cancelAfterFirstSendSender) Send(ctx context.Context, subject, body string, recipients []string) error {
+	err := s.MockSender.Send(ctx, subject, body, recipients)
+	s.cancel()
+	return err
+}
+
+// TestOutboxQueueProcessPendingStopsOnCanceledContext proves processPending
+// bails out of its sequential delivery loop as soon as ctx is canceled,
+// rather than working through every remaining item in the batch first.
+func TestOutboxQueueProcessPendingStopsOnCanceledContext(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &MockSender{}
+	sender := &cancelAfterFirstSendSender{MockSender: mock, cancel: cancel}
+
+	cfg := Config{
+		MaxRetries:     3,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+	}
+	queue := NewQueue(repo, sender, cfg, nil)
+
+	for i := range 3 {
+		item := &types.OutboxItem{
+			Subject:       "Item",
+			Body:          "Body",
+			Recipients:    []string{"user@test.com"},
+			Status:        types.OutboxPending,
+			NextAttemptAt: time.Now().Add(-time.Duration(3-i) * time.Second),
+		}
+		if err := repo.EnqueueOutboxItem(context.Background(), item); err != nil {
+			t.Fatalf("failed to enqueue: %v", err)
+		}
+	}
+
+	err := queue.processPending(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+
+	if got := mock.getCalled(); got != 1 {
+		t.Errorf("expected exactly 1 delivery attempt before bailing on cancellation, got %d", got)
+	}
+}

--- a/internal/outbox/outbox_test.go
+++ b/internal/outbox/outbox_test.go
@@ -100,13 +100,11 @@ func TestOutboxQueueHappyPath(t *testing.T) {
 		t.Fatalf("failed to enqueue: %v", err)
 	}
 
-	// Run outbox processPending once
+	// Run outbox processPending once; delivery is synchronous, so by the
+	// time this returns, the item has already been sent.
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-
-	// Wait for queue workers to finish
-	queue.wg.Wait()
 
 	// Verify sent email
 	sent := sender.getSent()
@@ -157,7 +155,6 @@ func TestOutboxQueueRetryBackoff(t *testing.T) {
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-	queue.wg.Wait()
 
 	fetched, err := repo.GetOutboxItem(ctx, item.ID)
 	if err != nil {
@@ -215,7 +212,6 @@ func TestOutboxQueuePermanentFailure(t *testing.T) {
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-	queue.wg.Wait()
 
 	fetched, err := repo.GetOutboxItem(ctx, item.ID)
 	if err != nil {
@@ -238,7 +234,6 @@ func TestOutboxQueuePermanentFailure(t *testing.T) {
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-	queue.wg.Wait()
 
 	if sender.getCalled() != 0 {
 		t.Errorf("expected 0 calls since item is failed, got %d", sender.getCalled())
@@ -264,7 +259,6 @@ func TestOutboxQueuePermanentFailure(t *testing.T) {
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-	queue.wg.Wait()
 
 	if sender.getCalled() != 0 {
 		t.Errorf("expected 0 calls since RetryCount >= MaxRetries, got %d", sender.getCalled())
@@ -447,7 +441,6 @@ func TestOutboxQueueDBCallbacks(t *testing.T) {
 		if err := queue.processPending(context.Background()); err != nil {
 			t.Fatalf("processPending failed: %v", err)
 		}
-		queue.wg.Wait()
 		// Status should still be delivering because final update failed
 		fetched, err := repo.GetOutboxItem(context.Background(), item.ID)
 		if err != nil {
@@ -495,7 +488,6 @@ func TestOutboxQueueDBCallbacks(t *testing.T) {
 		if err := queue.processPending(context.Background()); err != nil {
 			t.Fatalf("processPending failed: %v", err)
 		}
-		queue.wg.Wait()
 		// Status should still be delivering
 		fetched, err := repo.GetOutboxItem(context.Background(), item.ID)
 		if err != nil {
@@ -535,7 +527,6 @@ func TestOutboxQueueDistantFutureAndBoundary(t *testing.T) {
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-	queue.wg.Wait()
 
 	fetched, err := repo.GetOutboxItem(ctx, item.ID)
 	if err != nil {
@@ -575,9 +566,141 @@ func TestOutboxQueueDistantFutureAndBoundary(t *testing.T) {
 	if err := queue.processPending(ctx); err != nil {
 		t.Fatalf("processPending failed: %v", err)
 	}
-	queue.wg.Wait()
 
 	if sender.getCalled() != 0 {
 		t.Errorf("expected 0 calls since RetryCount matches MaxRetries, got %d", sender.getCalled())
 	}
+}
+
+// TestOutboxQueueSequentialOrder proves delivery is now fully sequential and
+// oldest-due-first, matching ListPendingOutboxItems' ORDER BY next_attempt_at.
+func TestOutboxQueueSequentialOrder(t *testing.T) {
+	repo := setupTestDB(t)
+	sender := &MockSender{}
+	ctx := context.Background()
+
+	cfg := Config{
+		MaxRetries:     3,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+		PollInterval:   5 * time.Millisecond,
+	}
+	queue := NewQueue(repo, sender, cfg, nil)
+
+	base := time.Now().Add(-time.Hour)
+	// Enqueue deliberately out of NextAttemptAt order.
+	items := []*types.OutboxItem{
+		{Subject: "third", Body: "b", Recipients: []string{"u@test.com"}, Status: types.OutboxPending, NextAttemptAt: base.Add(30 * time.Minute)},
+		{Subject: "first", Body: "b", Recipients: []string{"u@test.com"}, Status: types.OutboxPending, NextAttemptAt: base.Add(10 * time.Minute)},
+		{Subject: "second", Body: "b", Recipients: []string{"u@test.com"}, Status: types.OutboxPending, NextAttemptAt: base.Add(20 * time.Minute)},
+	}
+	for _, it := range items {
+		if err := repo.EnqueueOutboxItem(ctx, it); err != nil {
+			t.Fatalf("failed to enqueue: %v", err)
+		}
+	}
+
+	if err := queue.processPending(ctx); err != nil {
+		t.Fatalf("processPending failed: %v", err)
+	}
+
+	sent := sender.getSent()
+	if len(sent) != 3 {
+		t.Fatalf("expected 3 emails sent, got %d", len(sent))
+	}
+
+	wantOrder := []string{"first", "second", "third"}
+	gotOrder := make([]string, len(sent))
+	for i, s := range sent {
+		gotOrder[i] = s.Subject
+	}
+	for i, want := range wantOrder {
+		if gotOrder[i] != want {
+			t.Errorf("send order mismatch: got %v, want %v", gotOrder, wantOrder)
+			break
+		}
+	}
+}
+
+// blockingSender blocks in Send until release is closed, signaling once
+// (non-blocking) on started when a send has actually begun.
+type blockingSender struct {
+	release <-chan struct{}
+	started chan struct{}
+}
+
+func (b *blockingSender) Send(_ context.Context, _ string, _ string, _ []string) error {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-b.release
+	return nil
+}
+
+// TestOutboxQueueStopWaitsForInFlightDelivery proves Stop()'s documented
+// "waits for in-flight deliveries to complete" guarantee still holds after
+// re-scoping wg from per-item to per-processPending-call: Stop() called from
+// a goroutine other than Start's own must block until the currently
+// in-flight delivery actually finishes.
+func TestOutboxQueueStopWaitsForInFlightDelivery(t *testing.T) {
+	repo := setupTestDB(t)
+
+	release := make(chan struct{})
+	sender := &blockingSender{release: release, started: make(chan struct{}, 1)}
+	ctx := context.Background()
+
+	cfg := Config{
+		MaxRetries:     3,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+		PollInterval:   2 * time.Millisecond,
+	}
+	queue := NewQueue(repo, sender, cfg, nil)
+
+	item := &types.OutboxItem{
+		Subject:       "Slow Send",
+		Body:          "Body",
+		Recipients:    []string{"user@test.com"},
+		Status:        types.OutboxPending,
+		NextAttemptAt: time.Now().Add(-time.Second),
+	}
+	if err := repo.EnqueueOutboxItem(ctx, item); err != nil {
+		t.Fatalf("failed to enqueue: %v", err)
+	}
+
+	var startWg sync.WaitGroup
+	startWg.Go(func() {
+		_ = queue.Start(ctx)
+	})
+
+	// Wait until delivery has actually started, so Stop() below is
+	// guaranteed to race against real in-flight work, not an empty poll.
+	select {
+	case <-sender.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivery to start")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		queue.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop() returned before in-flight delivery completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after delivery completed")
+	}
+
+	startWg.Wait()
 }


### PR DESCRIPTION
## Summary

`SMTPSender` opened a fresh, freshly-authenticated connection on every `Send()` call, and the outbox queue spawned one goroutine per pending item on each poll tick. A burst of queued emails produced N simultaneous connect+login cycles against the SMTP server, tripping provider login-rate limits (e.g. Gmail's "too many logins").

Closes #120

## Changes

- `internal/notifier/notifier.go`: `SMTPSender` now caches a single mutex-guarded connection, reused across `Send()` calls with a `Noop` liveness check and reconnect-on-error, bounded by a per-operation I/O deadline (including inside the initial connect/greeting/STARTTLS/Auth sequence) so a stuck or silent server can't hang the shared connection indefinitely.
- `internal/outbox/outbox.go`: `processPending` delivers pending items sequentially instead of fanning out a goroutine per item, so the shared connection only ever has one caller. `Stop()`'s "waits for in-flight deliveries" guarantee is preserved via a mutex-guarded check-and-`Add`, closing a race that a naive re-scoping would otherwise reopen.

## Impact

No exported signatures changed. `notifier.Sender` and `outbox.Queue`'s public contract (`NewQueue`, `Start`, `Stop`, `Config`) are unchanged. `SendmailSender` and the mock notifier are unaffected — this only touches `SMTPSender`.

## Test plan

- `TestSMTPSenderConnectionReuse` / `TestSMTPSenderConcurrentSendsSerialize`: sequential and concurrent sends against a mock SMTP server both authenticate exactly once.
- `TestSMTPSenderReconnectAfterStaleConnection`, `TestSMTPSenderHungConnectBound`, `TestSMTPSenderHungReuseBound`: reconnect after a server-closed or silently-hung connection, bounded by the configured timeout.
- `TestSMTPSenderRcptRejected`, `TestSMTPSenderAuthRejected`: per-stage SMTP rejections discard the connection and redial cleanly.
- `TestOutboxQueueSequentialOrder`: delivery is oldest-due-first, matching the DB query's ordering.
- `TestOutboxQueueStopWaitsForInFlightDelivery`: `Stop()` still blocks until in-flight delivery completes.
- `go test ./... -race`: full module, clean.

## Notes

The mutex serializes the connection across the whole per-message SMTP transaction, so a stuck send can delay (bounded by the per-operation timeout) rather than run in parallel with other queued deliveries. This is an intentional tradeoff: the entire point of this change is to keep the app down to one physical connection/login regardless of queue depth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email delivery reliability by reusing healthy SMTP connections and reconnecting automatically when connections become unavailable.
  * Added operation timeouts and improved handling of stalled connections, rejected deliveries, and canceled requests.
  * Ensured queued messages are delivered sequentially and shutdown waits for active deliveries to finish.
  * Prevented additional queue processing after shutdown begins and stopped processing promptly when cancellation occurs.

* **Tests**
  * Expanded coverage for connection reuse, reconnection, timeouts, cancellation, delivery ordering, retries, and graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->